### PR TITLE
Support defining related models through field properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -303,12 +303,20 @@ You can use an ObjectField or a NestedField.
         manufacturer = fields.ObjectField(properties={
             'name': fields.StringField(),
             'country_code': fields.StringField(),
-        })
+        }, related_model=Manufacturer)  # Optional: ensure the Cars are updated when a Manufacturer is updated.
         ads = fields.NestedField(properties={
             'description': fields.StringField(analyzer=html_strip),
             'title': fields.StringField(),
             'pk': fields.IntegerField(),
-        })
+        }, related_model=Ad)  # Optional: ensure the Cars are updated when a Manufacturer is updated.
+
+        def get_instances_from_manufacturer(self, manufacturer):
+            # Mandatory when using related_model: define how the instance should be retrieved from the related model.
+            return manufacturer.car_set.all()
+
+        def get_instances_from_ads(self, ad):
+            # Mandatory when using related_model: define how the instance should be retrieved from the related model.
+            return ad.car
 
         class Meta:
             model = Car
@@ -316,20 +324,12 @@ You can use an ObjectField or a NestedField.
                 'name',
                 'color',
             ]
-            related_models = [Manufacturer, Ad]  # Optional: to ensure the Car will be re-saved when Manufacturer or Ad is updated
 
         def get_queryset(self):
             """Not mandatory but to improve performance we can select related in one sql request"""
             return super(CarDocument, self).get_queryset().select_related(
                 'manufacturer'
             )
-
-        def get_instances_from_related(self, related_instance):
-            """If related_models is set, define how to retrieve the Car instance(s) from the related model."""
-            if isinstance(related_instance, Manufacturer):
-                return related_instance.car_set.all()
-            elif isinstance(related_instance, Ad):
-                return related_instance.car
 
 
 Field Classes

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -29,9 +29,10 @@ from .exceptions import VariableLookupError
 
 
 class DEDField(Field):
-    def __init__(self, attr=None, **kwargs):
+    def __init__(self, attr=None, related_model=None, **kwargs):
         super(DEDField, self).__init__(**kwargs)
         self._path = attr.split('.') if attr else []
+        self._related_model = related_model
 
     def __setattr__(self, key, value):
         if key == 'get_value_from_instance':

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -19,7 +19,7 @@ class DocumentRegistry(object):
         """Register the model with the registry"""
         self._models[doc_class._doc_type.model].add(doc_class)
 
-        for related in doc_class._doc_type.related_models:
+        for related, method in iteritems(doc_class._doc_type.related_models):
             self._related_models[related].add(doc_class._doc_type.model)
 
         for idx, docs in iteritems(self._indices):
@@ -43,7 +43,13 @@ class DocumentRegistry(object):
 
         for doc in self._get_related_doc(instance):
             doc_instance = doc()
-            related = doc_instance.get_instances_from_related(instance)
+
+            method = getattr(
+                doc_instance,
+                doc._doc_type.related_models[instance.__class__]
+            )
+
+            related = method(instance)
             if related is not None:
                 doc_instance.update(related, **kwargs)
 
@@ -56,7 +62,13 @@ class DocumentRegistry(object):
 
         for doc in self._get_related_doc(instance):
             doc_instance = doc(related_instance_to_ignore=instance)
-            related = doc_instance.get_instances_from_related(instance)
+
+            method = getattr(
+                doc_instance,
+                doc._doc_type.related_models[instance.__class__]
+            )
+
+            related = method(instance)
             if related is not None:
                 doc_instance.update(related, **kwargs)
 

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -34,7 +34,7 @@ class CarDocument(DocType):
         'description': fields.StringField(analyzer=html_strip),
         'title': fields.StringField(),
         'pk': fields.IntegerField(),
-    })
+    }, related_model=Ad)
 
     categories = fields.NestedField(properties={
         'title': fields.StringField(),
@@ -42,9 +42,12 @@ class CarDocument(DocType):
         'icon': fields.FileField(),
     })
 
+    def get_instances_from_ads(self, ad):
+        return ad.car
+
     class Meta:
         model = Car
-        related_models = [Ad, Manufacturer, Category]
+        related_models = [Manufacturer, Category]
         fields = [
             'name',
             'launched',
@@ -56,10 +59,6 @@ class CarDocument(DocType):
             'manufacturer')
 
     def get_instances_from_related(self, related_instance):
-        if isinstance(related_instance, Ad):
-            return related_instance.car
-
-        # otherwise it's a Manufacturer or a Category
         return related_instance.car_set.all()
 
 


### PR DESCRIPTION
Currently, you can define and retrieve related models like so:

```
class CarDocument(Doctype):
    def get_instances_from_related(self, instance):
        if isinstance(instance, Manufacturer):
            return instance.car
        else:
            return instance.other.car

    class Meta:
        model = Car
        related_models = [Manufacturer, Country]
```

While this setup is workable, having all the `if-elif-else` checks in the function is not pretty.

Instead, I made it so you can now define your related models through the field definition. When doing so, the related models can be retrieved using special methods, like so:

```
class CarDocument(Doctype):
    manufacturer = ObjectField(related_models=[Manufacturer], fields={
        'country': TextField(related_models=[Country]),
    })

    def get_instances_from_manufacturer(self, instance):
        return instance.car_set.all()

    def get_instances_from_manufacturer_country(self, instance):
        return Car.objects.filter(manufacturer__country=instance).all()

    class Meta:
        model = Car
```

As you can see, every related model with every type of relation get it's own method, based on the fields the related model is defined on. So no more checking what input you get.