### PR TITLE
Implement the Celery signal processor

### DIFF
--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -107,5 +107,11 @@ class DocumentRegistry(object):
 
         return set(iterkeys(self._indices))
 
+    def __contains__(self, model):
+        """
+        Checks that model is in registry
+        """
+        return model in self._models or model in self._related_models
+
 
 registry = DocumentRegistry()

--- a/django_elasticsearch_dsl/signals.py
+++ b/django_elasticsearch_dsl/signals.py
@@ -7,6 +7,7 @@ cause things to index.
 from __future__ import absolute_import
 
 from django.db import models
+from django.apps import apps
 
 from .registries import registry
 
@@ -94,3 +95,58 @@ class RealTimeSignalProcessor(BaseSignalProcessor):
         models.signals.post_delete.disconnect(self.handle_delete)
         models.signals.m2m_changed.disconnect(self.handle_m2m_changed)
         models.signals.pre_delete.disconnect(self.handle_pre_delete)
+
+try:
+    from celery import shared_task
+except ImportError:
+    pass
+else:
+    class CelerySignalProcessor(RealTimeSignalProcessor):
+        """Celery signal processor.
+
+        Allows automatic updates on the index as delayed background tasks using
+        Celery.
+
+        NB: We cannot process deletes as background tasks.
+        By the time the Celery worker would pick up the delete job, the
+        model instance would already deleted. We can get around this by
+        setting Celery to use `pickle` and sending the object to the worker,
+        but using `pickle` opens the application up to security concerns.
+        """
+
+        def handle_save(self, sender, instance, **kwargs):
+            """Handle save with a Celery task.
+
+            Given an individual model instance, update the object in the index.
+            Update the related objects either.
+            """
+            pk = instance.pk
+            app_label = instance._meta.app_label
+            model_name = instance.__class__.__name__
+
+            self.registry_update_task.delay(pk, app_label, model_name)
+            self.registry_update_related_task.delay(pk, app_label, model_name)
+
+        @shared_task()
+        def registry_update_task(pk, app_label, model_name):
+            """Handle the update on the registry as a Celery task."""
+            try:
+                model = apps.get_model(app_label, model_name)
+            except LookupError:
+                pass
+            else:
+                registry.update(
+                    model.objects.get(pk=pk)
+                )
+
+        @shared_task()
+        def registry_update_related_task(pk, app_label, model_name):
+            """Handle the related update on the registry as a Celery task."""
+            try:
+                model = apps.get_model(app_label, model_name)
+            except LookupError:
+                pass
+            else:
+                registry.update_related(
+                    model.objects.get(pk=pk)
+                )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,4 +2,4 @@ bumpversion==0.5.3
 wheel==0.29.0
 django>=2.0,<2.1
 elasticsearch-dsl>=2.1.0,<6.0.0
-
+celery==4.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,6 @@ mock>=1.0.1
 flake8>=2.1.0
 tox>=1.7.0
 Pillow==4.2.1
-
+celery==4.1.0
 
 # Additional test requirements go here


### PR DESCRIPTION
The `CelerySignalProcessor` allows automatic updates on the index as delayed background tasks using Celery.

NB: We cannot process deletes as background tasks. By the time the Celery worker would pick up the delete job, the model instance would already deleted. We can get around this by setting Celery to use `pickle` and sending the object to the worker, but using `pickle` opens the application up to security concerns.

#34 