### PR TITLE
Fix perf when populate on huge qs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,9 @@ before_script:
   - sleep 10
 
 # command to run tests using coverage, e.g. python setup.py test
-script: tox -e $TOX_ENV -- --elasticsearch
+script:
+  - flake8
+  - tox -e $TOX_ENV -- --elasticsearch
 
 after_success:
   - codecov -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -544,7 +544,7 @@ Testing
 -------
 
 You can run the tests by creating a Python virtual environment, installing
-the requirements from ``requirements_test.txt`` (``pip install -r requirements_test``)::
+the requirements from ``requirements_test.txt`` (``pip install -r requirements_test.txt``)::
 
     $ python runtests.py
 

--- a/django_elasticsearch_dsl/utils.py
+++ b/django_elasticsearch_dsl/utils.py
@@ -1,0 +1,18 @@
+from itertools import islice
+
+
+def batch_iterate(qs, size=100):
+    """Efficient batching queryset
+
+    Django paginator can lead to performance issue with huge
+    queryset, make custom one based on pks presents in db right
+    now
+    """
+    qs_pks = qs.order_by('pk').values_list('pk', flat=True)
+    last_pk = qs_pks.last()
+    pks = list(islice(qs_pks, 0, None, size))
+    pks.append(last_pk + 1)
+
+    for lower, upper in zip(pks, pks[1:]):
+        ranged_qs = qs.filter(pk__range=(lower, upper - 1))
+        yield ranged_qs

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ tag = True
 [wheel]
 universal = 1
 
+[flake8]
+filename = ./django_elasticsearch_dsl/**.py, ./tests/**.py
+max-line-length = 99

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -50,6 +50,7 @@ class CarDocument(DocType):
             'name',
             'launched',
             'type',
+            'price',
         ]
         doc_type = 'car_document'
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,11 +7,16 @@ from django.utils.translation import ugettext_lazy as _
 
 @python_2_unicode_compatible
 class Car(models.Model):
+    TYPE_SEDAN = 'se'
+    TYPE_BREAK = 'br'
+    TYPE_4X4 = '4x'
+    TYPE_COUPE = 'co'
+
     TYPE_CHOICES = (
-        ('se', "Sedan"),
-        ('br', "Break"),
-        ('4x', "4x4"),
-        ('co', "Coupé"),
+        (TYPE_SEDAN, "Sedan"),
+        (TYPE_BREAK, "Break"),
+        (TYPE_4X4, "4x4"),
+        (TYPE_COUPE, "Coupé"),
     )
 
     name = models.CharField(max_length=255)
@@ -25,6 +30,7 @@ class Car(models.Model):
         'Manufacturer', null=True, on_delete=models.SET_NULL
     )
     categories = models.ManyToManyField('Category')
+    price = models.FloatField(null=True)
 
     class Meta:
         app_label = 'tests'


### PR DESCRIPTION
Fix #86

- create a custom paginator based on pks
- Add test and refactor tests_documents to use models.py and documents.py
- make travis run flake8 