### PR TITLE
Logerrors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -508,7 +508,7 @@ Default: ``True``
 
 Set to ``False`` to globally disable auto-syncing.
 
-ELASTICSEARCH_DSL_AUTOSYNC_LOGERRORS
+ELASTICSEARCH_DSL_AUTOSYNC_LOG_ERRORS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Default: ``False``

--- a/README.rst
+++ b/README.rst
@@ -508,6 +508,13 @@ Default: ``True``
 
 Set to ``False`` to globally disable auto-syncing.
 
+ELASTICSEARCH_DSL_AUTOSYNC_LOGERRORS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``False``
+
+Set to ``True`` to log (but not raise) errors during auto-syncing. Deletion never raises (but this option controls the logging of deletion errors). Note that you should periodically rebuild your index to resolve drift. Note also that it is important to ensure errors are visible (i.e. Sentry) so that you can correct indexing issues.
+
 ELASTICSEARCH_DSL_INDEX_SETTINGS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/django_elasticsearch_dsl/signals.py
+++ b/django_elasticsearch_dsl/signals.py
@@ -55,16 +55,10 @@ class BaseSignalProcessor(object):
         # Do nothing.
 
     def handle_m2m_changed(self, sender, instance, action, **kwargs):
-        try:
-            if action in ('post_add', 'post_remove', 'post_clear'):
-                self.handle_save(sender, instance)
-            elif action in ('pre_remove', 'pre_clear'):
-                self.handle_pre_delete(sender, instance)
-
-        except (ElasticsearchException, ElasticsearchDslException):
-            if not LOG_ERRORS:
-                raise
-            LOGGER.exception('Error during auto-sync %s, continuing', action)
+        if action in ('post_add', 'post_remove', 'post_clear'):
+            self.handle_save(sender, instance)
+        elif action in ('pre_remove', 'pre_clear'):
+            self.handle_pre_delete(sender, instance)
 
     def handle_save(self, sender, instance, **kwargs):
         """Handle save.
@@ -102,7 +96,7 @@ class BaseSignalProcessor(object):
         try:
             registry.delete(instance)
 
-        except (ElasticsearchException, ElasticsearchDslException):
+        except Exception:
             if not LOG_ERRORS:
                 # Preserve functionality, don't ever raise during deletion, but
                 # optionally log.

--- a/django_elasticsearch_dsl/signals.py
+++ b/django_elasticsearch_dsl/signals.py
@@ -6,9 +6,18 @@ cause things to index.
 
 from __future__ import absolute_import
 
+import logging
+
 from django.db import models
+from django.conf import settings
 
 from .registries import registry
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.NullHandler())
+
+LOG_ERRORS = getattr(settings, 'ELASTICSEARCH_DSL_AUTOSYNC_LOGERRORS', False)
 
 
 class BaseSignalProcessor(object):
@@ -43,10 +52,16 @@ class BaseSignalProcessor(object):
         # Do nothing.
 
     def handle_m2m_changed(self, sender, instance, action, **kwargs):
-        if action in ('post_add', 'post_remove', 'post_clear'):
-            self.handle_save(sender, instance)
-        elif action in ('pre_remove', 'pre_clear'):
-            self.handle_pre_delete(sender, instance)
+        try:
+            if action in ('post_add', 'post_remove', 'post_clear'):
+                self.handle_save(sender, instance)
+            elif action in ('pre_remove', 'pre_clear'):
+                self.handle_pre_delete(sender, instance)
+
+        except:
+            if not LOG_ERRORS:
+                raise
+            LOGGER.exception('Error during auto-sync %s, continuing', action)
 
     def handle_save(self, sender, instance, **kwargs):
         """Handle save.
@@ -54,22 +69,42 @@ class BaseSignalProcessor(object):
         Given an individual model instance, update the object in the index.
         Update the related objects either.
         """
-        registry.update(instance)
-        registry.update_related(instance)
+        try:
+            registry.update(instance)
+            registry.update_related(instance)
+
+        except:
+            if not LOG_ERRORS:
+                raise
+            LOGGER.exception('Error during auto-sync save, continuing')
 
     def handle_pre_delete(self, sender, instance, **kwargs):
         """Handle removing of instance object from related models instance.
         We need to do this before the real delete otherwise the relation
         doesn't exists anymore and we can't get the related models instance.
         """
-        registry.delete_related(instance)
+        try:
+            registry.delete_related(instance)
+
+        except:
+            if not LOG_ERRORS:
+                raise
+            LOGGER.exception('Error during auto-sync pre-delete, continuing')
 
     def handle_delete(self, sender, instance, **kwargs):
         """Handle delete.
 
         Given an individual model instance, delete the object from index.
         """
-        registry.delete(instance, raise_on_error=False)
+        try:
+            registry.delete(instance)
+
+        except:
+            if not LOG_ERRORS:
+                # Preserve functionality, don't ever raise during deletion, but
+                # optionally log.
+                return
+            LOGGER.exception('Error during auto-sync delete, continuing')
 
 
 class RealTimeSignalProcessor(BaseSignalProcessor):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,92 @@
+from mock import patch
+from unittest import TestCase
+
+from django.conf import settings
+
+from elasticsearch.exceptions import ElasticsearchException
+
+from django_elasticsearch_dsl import signals
+
+
+class LogErrorsTestCase(TestCase):
+    def test_log_errors_default(self):
+        # Ensure default behavior is correct.
+        self.assertFalse(signals.LOG_ERRORS)
+
+    @patch('django_elasticsearch_dsl.signals.LOGGER')
+    @patch('django_elasticsearch_dsl.signals.registry')
+    def test_log_errors_on(self, m_registry, m_logger):
+        # Object under test.
+        rtsp = signals.RealTimeSignalProcessor(None)
+
+        # Testing with the option enabled (non-default).
+        signals.LOG_ERRORS = True
+        try:
+            # delete() is special. It logs all errors.
+            m_registry.delete.side_effect = ElasticsearchException()
+            rtsp.handle_delete(None, None)
+            self.assertEqual(1, m_logger.exception.call_count)
+
+            m_registry.delete.side_effect = ValueError()
+            rtsp.handle_delete(None, None)
+            self.assertEqual(2, m_logger.exception.call_count)
+
+            # Other methods only log Elasticsearch specific errors and raise
+            # # others.
+            m_registry.delete_related.side_effect = ElasticsearchException()
+            rtsp.handle_pre_delete(None, None)
+            self.assertEqual(3, m_logger.exception.call_count)
+
+            m_registry.delete_related.side_effect = ValueError()
+            with self.assertRaises(ValueError):
+               rtsp.handle_pre_delete(None, None)
+
+            m_registry.update.side_effect = ElasticsearchException()
+            rtsp.handle_save(None, None)
+            self.assertEqual(4, m_logger.exception.call_count)
+
+            m_registry.update.side_effect = ValueError()
+            with self.assertRaises(ValueError):
+               rtsp.handle_save(None, None)
+
+        finally:
+            signals.LOG_ERRORS = False
+
+    @patch('django_elasticsearch_dsl.signals.LOGGER')
+    @patch('django_elasticsearch_dsl.signals.registry')
+    def test_log_errors_off(self, m_registry, m_logger):
+        # Object under test.
+        rtsp = signals.RealTimeSignalProcessor(None)
+        
+        # Default case, but be sure.
+        signals.LOG_ERRORS = False
+
+        # delete() is special. It ignores all errors, the LOG_ERRORS option
+        # controls logging only.
+        m_registry.delete.side_effect = ElasticsearchException
+        rtsp.handle_delete(None, None)
+        self.assertFalse(m_logger.exception.called)
+
+        m_registry.delete.side_effect = ValueError()
+        rtsp.handle_delete(None, None)
+        self.assertFalse(m_logger.exception.called)
+
+        m_registry.delete_related.side_effect = ElasticsearchException()
+        with self.assertRaises(ElasticsearchException):
+            rtsp.handle_pre_delete(None, None)
+        self.assertFalse(m_logger.exception.called)
+
+        m_registry.delete_related.side_effect = ValueError()
+        with self.assertRaises(ValueError):
+            rtsp.handle_pre_delete(None, None)
+        self.assertFalse(m_logger.exception.called)
+
+        m_registry.update.side_effect = ElasticsearchException()
+        with self.assertRaises(ElasticsearchException):
+            rtsp.handle_save(None, None)
+        self.assertFalse(m_logger.exception.called)
+
+        m_registry.update.side_effect = ValueError()
+        with self.assertRaises(ValueError):
+            rtsp.handle_save(None, None)
+        self.assertFalse(m_logger.exception.called)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -71,6 +71,7 @@ class LogErrorsTestCase(TestCase):
         rtsp.handle_delete(None, None)
         self.assertFalse(m_logger.exception.called)
 
+        # All other methods raise exceptions when LOG_ERRORS is disabled.
         m_registry.delete_related.side_effect = ElasticsearchException()
         with self.assertRaises(ElasticsearchException):
             rtsp.handle_pre_delete(None, None)


### PR DESCRIPTION
This PR address #31 by introducing a setting. `ELASTICSEARCH_DSL_AUTOSYNC_LOG_ERRORS`. This setting is `False` by default (current functionality is preserved). However, when enabled, errors are logged (but not raised) by the `BaseSignalProcessor` and it's subclasses.

I want this option to allow myself to have best effort real time indexing without sinking the ship for every indexing error. This option in combination with periodic rebuild of the indexes should provide the trade-off I am looking for.