### PR TITLE
Added http_auth example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,8 @@ For example:
 
     ELASTICSEARCH_DSL={
         'default': {
-            'hosts': 'localhost:9200'
+            'hosts': ['localhost:9200'],
+            'http_auth': ['username', 'password']
         },
     }
 


### PR DESCRIPTION
An example for "http_auth" with username and password was added in README.
"hosts" can accept arrays and the example value was changed to an array.