### PR TITLE
Auto-generate Nested and Object fields from DocType

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -338,6 +338,78 @@ You can use an ObjectField or a NestedField.
             elif isinstance(related_instance, Ad):
                 return related_instance.car
 
+A simpler alternative to auto generate nested fields is using the ```related_model_settings``` parameter. This automatically generates the required fields. Below is an example of how you can use the ```related_model_settings``` parameter to auto generate your Object / Nested fields.
+
+.. code-block:: python
+
+    # documents.py
+
+
+    class CarDocumentWithout(DocType):
+        manufacturer = fields.ObjectField(properties={
+            'name': fields.TextField(),
+            'country_code': fields.TextField(),
+            'created': fields.DateField(),
+            'logo': fields.FileField()
+        })
+        ads = fields.NestedField(properties={
+            'description': fields.TextField(),
+            'title': fields.TextField(),
+            'created': fields.DateField(),
+            'modified': fields.DateField(),
+            'url': fields.TextField(),
+        })
+        categories = fields.NestedField(properties={
+            'title': fields.TextField(),
+            'slug': fields.TextField(),
+            'icon': fields.FileField()
+        })
+
+        class Meta:
+            fields = ['name', 'launched', 'type']
+            model = Car
+            index = 'car_index'
+            related_models = [Manufacturer, Ad, Category]
+            doc_type = 'car_document'
+
+    class CarDocumentWith(DocType):
+        class Meta:
+            model = Car
+            index = 'car_index'
+            related_models = [Manufacturer, Ad]
+            doc_type = 'car_document'
+            related_model_settings = {
+                Ad: {
+                    'name': 'ads',
+                    'exclude': ['id'],
+                },
+                Manufacturer: {
+                    'name': 'manufacturer',
+                    'type': fields.ObjectField,
+                    'exclude': ['id'],
+                },
+                Category: {
+                    'name': 'categories',
+                    'exclude': ['id'],
+                }
+            }
+            fields = ['name', 'launched', 'type']
+
+        #   related_model_settings = {
+        #        Model: {
+        #            'name': Name of the nested attribute // default(field name in Model)
+        #            'type': fields.Nested or fields.Object // default(Nested)
+        #            'include': fields to include // default(All Fields)
+        #            'exclude': fields to exclude // default(No Field)
+        #            'fields': { // Used to override generated fields
+        #                'field_name': fields.TextField(attr='', analyzer=...)
+        #            }
+        #            'analyzer': analyzer object // Given to all generated fields
+        #        }
+        #}
+
+In the above example, both of the documents generate an equivalent mapping.
+
 
 Field Classes
 ~~~~~~~~~~~~~
@@ -565,6 +637,6 @@ TODO
 - Add support for --using (use another Elasticsearch cluster) in management commands.
 - Add management commands for mapping level operations (like update_mapping....).
 - Dedicated documentation.
-- Generate ObjectField/NestField properties from a DocType class.
 - More examples.
 - Better ``ESTestCase`` and documentation for testing
+- Support sub-nested fields. Currently only non-relation fields are auto-generated

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -9,7 +9,11 @@ from elasticsearch_dsl.document import DocTypeMeta as DSLDocTypeMeta
 from elasticsearch_dsl.field import Field
 
 from .apps import DEDConfig
-from .exceptions import ModelFieldNotMappedError, RedeclaredFieldError, InvalidModelSettingsError
+from .exceptions import (
+    ModelFieldNotMappedError,
+    RedeclaredFieldError,
+    InvalidModelSettingsError
+)
 from .fields import (
     BooleanField,
     DateField,
@@ -21,7 +25,6 @@ from .fields import (
     LongField,
     ShortField,
     TextField,
-    ObjectField,
     NestedField,
 )
 from .indices import Index
@@ -87,13 +90,18 @@ class DocTypeMeta(DSLDocTypeMeta):
             attrs['Meta'], 'related_model_settings', {}
         )
 
-        related_fields = [field for field in fields
-            if field.is_relation and related_model_settings.get(field.related_model, None)]
+        related_fields = [
+            field for field in fields
+            if field.is_relation and
+            related_model_settings.get(
+                                field.related_model, None)]
         for related_field in related_fields:
             related_model = related_field.related_model
             # Currently preventing sub-nested fields.
-            related_model_field_lookup = dict((field.name, field)
-                for field in related_model._meta.get_fields() if not field.is_relation)
+            related_model_field_lookup = dict(
+                (field.name, field)
+                for field in related_model._meta.get_fields()
+                if not field.is_relation)
 
             conf = related_model_settings.get(related_model)
             settings = {}
@@ -110,18 +118,28 @@ class DocTypeMeta(DSLDocTypeMeta):
                 for field_name in fields_to_include:
                     if field_name not in related_model_field_lookup.keys():
                         raise InvalidModelSettingsError(
-                            "Cannot find field {} in model {}".format(field_name, related_model.__name__)
+                            "Cannot find field {} in model {}".format(
+                                field_name,
+                                related_model.__name__
+                            )
                         )
-                related_model_field_lookup = { field_name: related_model_field_lookup[field_name]
+                related_model_field_lookup = {
+                    field_name: related_model_field_lookup[field_name]
                     for field_name in fields_to_include}
             if fields_to_exclude:
                 for field_name in fields_to_exclude:
                     if field_name not in related_model_field_lookup.keys():
                         raise InvalidModelSettingsError(
-                            "Cannot find field {} in model {}".format(field_name, related_model.__name__)
+                            "Cannot find field {} in model {}".format(
+                                field_name,
+                                related_model.__name__
+                            )
                         )
-                related_model_field_lookup = { field_name: related_model_field_lookup[field_name]
-                    for field_name in related_model_field_lookup.keys() if field_name not in fields_to_exclude}
+                related_model_field_lookup = {
+                    field_name: related_model_field_lookup[field_name]
+                    for field_name in related_model_field_lookup.keys()
+                    if field_name not in fields_to_exclude
+                }
             # Prioritize user defined fields
             override_fields = conf.get('fields', {})
 

--- a/django_elasticsearch_dsl/exceptions.py
+++ b/django_elasticsearch_dsl/exceptions.py
@@ -12,3 +12,7 @@ class RedeclaredFieldError(DjangoElasticsearchDslError):
 
 class ModelFieldNotMappedError(DjangoElasticsearchDslError):
     pass
+
+
+class InvalidModelSettingsError(DjangoElasticsearchDslError):
+    pass

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -140,6 +140,60 @@ class DocTypeTestCase(TestCase):
                 }
             }
         )
+    def test_mapping_with_related_model_settings(self):
+        from .models import Car, Manufacturer, Ad, Category
+        class CarDocumentWithout(DocType):
+            manufacturer = fields.ObjectField(properties={
+                'name': fields.TextField(),
+                'country_code': fields.TextField(),
+                'created': fields.DateField(),
+                'logo': fields.FileField()
+            })
+            ads = fields.NestedField(properties={
+                'description': fields.TextField(),
+                'title': fields.TextField(),
+                'created': fields.DateField(),
+                'modified': fields.DateField(),
+                'url': fields.TextField(),
+            })
+            categories = fields.NestedField(properties={
+                'title': fields.TextField(),
+                'slug': fields.TextField(),
+                'icon': fields.FileField()
+            })
+
+            class Meta:
+                fields = ['name', 'launched', 'type']
+                model = Car
+                index = 'car_index'
+                related_models = [Manufacturer, Ad, Category]
+                doc_type = 'car_document'
+
+        class CarDocumentWith(DocType):
+            class Meta:
+                model = Car
+                index = 'car_index'
+                related_models = [Manufacturer, Ad]
+                doc_type = 'car_document'
+                related_model_settings = {
+                    Ad: {
+                        'name': 'ads',
+                        'exclude': ['id'],
+                    },
+                    Manufacturer: {
+                        'name': 'manufacturer',
+                        'type': fields.ObjectField,
+                        'exclude': ['id'],
+                    },
+                    Category: {
+                        'name': 'categories',
+                        'exclude': ['id'],
+                    }
+                }
+                fields = ['name', 'launched', 'type']
+
+        self.assertEqual(CarDocumentWith._doc_type.mapping.to_dict(),
+        CarDocumentWithout._doc_type.mapping.to_dict())
 
     def test_get_queryset(self):
         qs = CarDocument().get_queryset()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -140,8 +140,10 @@ class DocTypeTestCase(TestCase):
                 }
             }
         )
+
     def test_mapping_with_related_model_settings(self):
         from .models import Car, Manufacturer, Ad, Category
+
         class CarDocumentWithout(DocType):
             manufacturer = fields.ObjectField(properties={
                 'name': fields.TextField(),
@@ -192,8 +194,10 @@ class DocTypeTestCase(TestCase):
                 }
                 fields = ['name', 'launched', 'type']
 
-        self.assertEqual(CarDocumentWith._doc_type.mapping.to_dict(),
-        CarDocumentWithout._doc_type.mapping.to_dict())
+        self.assertEqual(
+            CarDocumentWith._doc_type.mapping.to_dict(),
+            CarDocumentWithout._doc_type.mapping.to_dict()
+        )
 
     def test_get_queryset(self):
         qs = CarDocument().get_queryset()


### PR DESCRIPTION
Currently, a lot of extra code is required in defining the mapping of the nested fields for more complicated mapping. This can be a real pain when working with a larger database schema. So now, when the DocTypeMeta class is being instantiated, the ```__new__``` method reads the ```related_model_settings``` attribute which just contains parts of schema that requires manual overriding (Please refer to updated readme for an example). 

The method then simply parses the attribute and generates Object / Nested fields respectively and adds to ```attrs```.

Currently, sub-nested methods are ignored to prevent excessively huge entries in the index. This can be easily extended in the future.