### PR TITLE
fixbug: 运行 command search_index 时, 只使用 default 的 using. 不识别 meta 中指定的…

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -104,8 +104,8 @@ class DocTypeMeta(DSLDocTypeMeta):
         cls._doc_type._fields = (
             lambda: cls._doc_type.mapping.properties.properties.to_dict())
 
-        if getattr(cls._doc_type, 'index'):
-            index = Index(cls._doc_type.index)
+        if getattr(cls._doc_type, 'index') and getattr(cls._doc_type, 'using'):
+            index = Index(cls._doc_type.index, cls._doc_type.using)
             index.doc_type(cls)
             registry.register(index, cls)
 


### PR DESCRIPTION
fixbug: 运行 command search_index 时, 只使用 default 的 using. 不识别 meta 中指定的 using.