### PR TITLE
Feature/respect verbosity

### DIFF
--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -102,13 +102,13 @@ class Command(BaseCommand):
 
     def _create(self, models, options):
         for index in registry.get_indices(models):
-            self.stdout.write("Creating index '{}'".format(index._name))
+            self.verbose_write("Creating index '{}'".format(index._name))
             index.create()
 
     def _populate(self, models, options):
         parallel = options['parallel']
         for doc in registry.get_documents(models):
-            self.stdout.write("Indexing {} '{}' objects {}".format(
+            self.verbose_write("Indexing {} '{}' objects {}".format(
                 doc().get_queryset().count() if options['count'] else "all",
                 doc.django.model.__name__,
                 "(parallel)" if parallel else "")
@@ -124,11 +124,11 @@ class Command(BaseCommand):
                 "Are you sure you want to delete "
                 "the '{}' indexes? [n/Y]: ".format(", ".join(index_names)))
             if response.lower() != 'y':
-                self.stdout.write('Aborted')
+                self.verbose_write('Aborted')
                 return False
 
         for index in registry.get_indices(models):
-            self.stdout.write("Deleting index '{}'".format(index._name))
+            self.verbose_write("Deleting index '{}'".format(index._name))
             index.delete(ignore=404)
         return True
 
@@ -139,7 +139,12 @@ class Command(BaseCommand):
         self._create(models, options)
         self._populate(models, options)
 
+    def verbose_write(self, *args, **kwargs):
+        if self.verbosity > 0:
+            self.stdout.write(*args, **kwargs)
+
     def handle(self, *args, **options):
+        self.verbosity = int(options['verbosity'])
         if not options['action']:
             raise CommandError(
                 "No action specified. Must be one of"

--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -144,7 +144,7 @@ class Command(BaseCommand):
             self.stdout.write(*args, **kwargs)
 
     def handle(self, *args, **options):
-        self.verbosity = int(options['verbosity'])
+        self.verbosity = int(options.get('verbosity', 1))
         if not options['action']:
             raise CommandError(
                 "No action specified. Must be one of"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,7 @@
-from mock import Mock
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
 
 from django.db import models
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,8 @@
-from mock import DEFAULT, Mock, patch
+try:
+    from mock import DEFAULT, Mock, patch
+except ImportError:
+    from unittest.mock import DEFAULT, Mock, patch
+
 from unittest import TestCase
 
 from django.core.management.base import CommandError

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -6,7 +6,7 @@ from elasticsearch_dsl import GeoPoint, MetaField
 try:
     from mock import patch, Mock, PropertyMock
 except ImportError:
-    from unittest.mock import patch Mock, PropertyMock
+    from unittest.mock import patch, Mock, PropertyMock
 
 from django_elasticsearch_dsl import fields
 from django_elasticsearch_dsl.documents import DocType

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -3,7 +3,10 @@ from unittest import TestCase
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from elasticsearch_dsl import GeoPoint, MetaField
-from mock import patch, Mock, PropertyMock
+try:
+    from mock import patch, Mock, PropertyMock
+except ImportError:
+    from unittest.mock import patch Mock, PropertyMock
 
 from django_elasticsearch_dsl import fields
 from django_elasticsearch_dsl.documents import DocType

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,10 @@ from unittest import TestCase
 
 from django.db.models.fields.files import FieldFile
 from django.utils.translation import ugettext_lazy as _
-from mock import Mock, NonCallableMock
+try:
+    from mock import Mock, NonCallableMock
+except ImportError:
+    from unittest.mock import Mock, NonCallableMock
 from six import string_types
 
 from django_elasticsearch_dsl.exceptions import VariableLookupError

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1,5 +1,8 @@
 from unittest import TestCase
-from mock import patch
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 
 from django.conf import settings
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,4 +1,7 @@
-from mock import Mock
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
 from unittest import TestCase
 
 from django.conf import settings


### PR DESCRIPTION
Make the search_index command respect Django's --verbosity flag.
This is useful for silencing output when using search_index in testing.

Also included in this pull request is updates to tests that use the mock package.
In python3 it is replaced by unittest.mock.
If the mock package is not available, then try to import objects from unittest.mock.