### PR TITLE
Add elasticsearch online/offline checker

### DIFF
--- a/django_elasticsearch_dsl/test/__init__.py
+++ b/django_elasticsearch_dsl/test/__init__.py
@@ -1,4 +1,4 @@
-from .testcases import ESTestCase
+from .testcases import ESTestCase, is_es_online
 
 
-__all__ = ['ESTestCase']
+__all__ = ['ESTestCase', 'is_es_online']

--- a/django_elasticsearch_dsl/test/testcases.py
+++ b/django_elasticsearch_dsl/test/testcases.py
@@ -1,5 +1,15 @@
 import re
+
+from django.test.utils import captured_stderr
+from elasticsearch_dsl import connections
+
 from ..registries import registry
+
+
+def is_es_online(connection_alias='default'):
+    with captured_stderr():
+        es = connections.get_connection(connection_alias)
+        return es.ping()
 
 
 class ESTestCase(object):

--- a/django_elasticsearch_dsl/test/testcases.py
+++ b/django_elasticsearch_dsl/test/testcases.py
@@ -1,7 +1,7 @@
 import re
 
 from django.test.utils import captured_stderr
-from elasticsearch_dsl import connections
+from elasticsearch_dsl.connections import connections
 
 from ..registries import registry
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import os
 import unittest
 
 from django.core.management import call_command
@@ -8,7 +7,7 @@ from django.utils.six import StringIO
 from django.utils.translation import ugettext_lazy as _
 
 from elasticsearch_dsl import Index as DSLIndex
-from django_elasticsearch_dsl.test import ESTestCase
+from django_elasticsearch_dsl.test import ESTestCase, is_es_online
 from tests import ES_MAJOR_VERSION
 
 from .documents import (
@@ -24,10 +23,7 @@ from .documents import (
 from .models import Car, Manufacturer, Ad, Category, COUNTRIES
 
 
-@unittest.skipUnless(
-    os.environ.get('ELASTICSEARCH_URL', False),
-    "--elasticsearch not set"
-)
+@unittest.skipUnless(is_es_online(), 'Elasticsearch is offline')
 class IntegrationTestCase(ESTestCase, TestCase):
     def setUp(self):
         super(IntegrationTestCase, self).setUp()


### PR DESCRIPTION
Added a helper function to check whether elasticsearch is online. 
This allows to skip integration tests when elasticsearch is down.