### PR TITLE
Allow choosing documents by list of index names during indexing

### DIFF
--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -147,10 +147,13 @@ class DocumentRegistry(object):
         """
         self.update(instance, action="delete", **kwargs)
 
-    def get_documents(self, models=None):
+    def get_documents(self, models=None, indices=None):
         """
-        Get all documents in the registry or the documents for a list of models
+        Get all documents in the registry or the documents for a list of models or indices
         """
+        if indices is not None:
+            return set(chain(*(docs for idx, docs in iteritems(registry._indices) if idx._name in indices)))
+
         if models is not None:
             return set(chain(*(self._models[model] for model in models
                                if model in self._models)))
@@ -162,10 +165,13 @@ class DocumentRegistry(object):
         """
         return set(iterkeys(self._models))
 
-    def get_indices(self, models=None):
+    def get_indices(self, models=None, indices=None):
         """
-        Get all indices in the registry or the indices for a list of models
+        Get all indices in the registry or the indices for a list of models or indices
         """
+        if indices is not None:
+            return set(idx for idx in iterkeys(self._indices) if idx._name in indices)
+
         if models is not None:
             return set(
                 indice for indice, docs in iteritems(self._indices)

--- a/docs/source/management.rst
+++ b/docs/source/management.rst
@@ -1,28 +1,28 @@
 Management Commands
 ###################
 
-Delete all indices in Elasticsearch or only the indices associate with a model (``--models``):
+Delete all indices in Elasticsearch or only the indices associate with a model (``--models``) or with an index (``--indices``):
 
 ::
 
-    $ search_index --delete [-f] [--models [app[.model] app[.model] ...]]
+    $ search_index --delete [-f] [--models [app[.model] app[.model] ...]] [--indices [index index ...]]
 
 
 Create the indices and their mapping in Elasticsearch:
 
 ::
 
-    $ search_index --create [--models [app[.model] app[.model] ...]]
+    $ search_index --create [--models [app[.model] app[.model] ...]] [--indices [index index ...]]
 
 Populate the Elasticsearch mappings with the django models data (index need to be existing):
 
 ::
 
-    $ search_index --populate [--models [app[.model] app[.model] ...]] [--parallel]
+    $ search_index --populate [--models [app[.model] app[.model] ...]] [--indices [index index ...]] [--parallel]
 
 Recreate and repopulate the indices:
 
 ::
 
-    $ search_index --rebuild [-f] [--models [app[.model] app[.model] ...]] [--parallel]
+    $ search_index --rebuild [-f] [--models [app[.model] app[.model] ...]] [--indices [index index ...]] [--parallel]
 


### PR DESCRIPTION
It is possible to use multiple indices for the same model. With current `search_index` command, your only chance is to rebuild/create/delete/populate them together. However it can be desirable to run indexing separately for the different indices related to same model. This pr handles that by providing optional arg on top of `search_index` command. 

e.g.

`./manage.py search_index --rebuild index_1 index_2` will only operate on index_1 and index_2 independent of the models

