### PR TITLE
Support Elasticsearch 6

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -49,7 +49,6 @@ model_field_class_to_field_class = {
     models.URLField: TextField,
 }
 
-es_connection = get_connection()
 
 class DocType(DSLDocument):
     _prepared_fields = []
@@ -168,7 +167,7 @@ class DocType(DSLDocument):
                 self.prepare(object_instance) if action != 'delete' else None
             ),
         }
-
+        es_connection = get_connection()
         if es_connection.info()['version']['number'][0] == '6':
             prepared_object['_type'] = self._doc_type.name
 

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -160,6 +160,7 @@ class DocType(DSLDocument):
         return {
             '_op_type': action,
             '_index': self._index._name,
+            '_type': self._doc_type.name,
             '_id': object_instance.pk,
             '_source': (
                 self.prepare(object_instance) if action != 'delete' else None

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'elasticsearch-dsl>=7.0.0<8.0.0',
+        'elasticsearch-dsl<7.0.0',
         'six',
     ],
     license="Apache Software License 2.0",


### PR DESCRIPTION
In my personal testing it seems like the only thing needed for Elasticsearch 6 to work with 7.x of this repo is:
1. To be using `elasticsearch>=6.0.0,<7.0.0 elasticsearch-dsl>=6.0.0,<7.0.0`
2. For the object sent to elasticsearch during indexing includes `_type`

I've implemented the ability to determine if you are using ES6 if so then the `_type` field is included

This *should* work with both ES6 and ES7, haven't tested on any other versions