### PR TITLE
[Fix #111] Adding API for filtering object while indexing

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -189,6 +189,7 @@ class DocType(DSLDocument):
             return self.bulk(*args, **kwargs)
 
     def should_index_object(self, obj):
+        """Overwriting this method and returning a boolean value should determine whether the object should be index."""
         return True
 
     def update(self, thing, refresh=None, action='index', parallel=False, **kwargs):

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -159,8 +159,8 @@ class DocType(DSLDocument):
     @classmethod
     def generate_id(cls, object_instance):
         """
-        The default behavior is to use the Django object's pk (id) as the 
-        elasticseach index id (_id). If needed, this method can be overloaded 
+        The default behavior is to use the Django object's pk (id) as the
+        elasticseach index id (_id). If needed, this method can be overloaded
         to change this default behavior.
         """
         return object_instance.pk
@@ -177,7 +177,8 @@ class DocType(DSLDocument):
 
     def _get_actions(self, object_list, action):
         for object_instance in object_list:
-            yield self._prepare_action(object_instance, action)
+            if self.should_index_object(object_instance):
+                yield self._prepare_action(object_instance, action)
 
     def _bulk(self, *args, **kwargs):
         """Helper for switching between normal and parallel bulk operation"""
@@ -186,6 +187,9 @@ class DocType(DSLDocument):
             return self.parallel_bulk(*args, **kwargs)
         else:
             return self.bulk(*args, **kwargs)
+
+    def should_index_object(self, obj):
+        return True
 
     def update(self, thing, refresh=None, action='index', parallel=False, **kwargs):
         """

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -189,7 +189,10 @@ class DocType(DSLDocument):
             return self.bulk(*args, **kwargs)
 
     def should_index_object(self, obj):
-        """Overwriting this method and returning a boolean value should determine whether the object should be index."""
+        """
+        Overwriting this method and returning a boolean value 
+        should determine whether the object should be indexed.
+        """
         return True
 
     def update(self, thing, refresh=None, action='index', parallel=False, **kwargs):


### PR DESCRIPTION
This fixes #111. We need to add documentation for this. But I am not sure where to add it.
overwriting the `should_index_object` and returning a boolean value should determine which object should be index.

For example, if we want to index Car only with Red `color`, we can write following
```python
class Car(Document):
    def should_index_object(self, obj):
        if obj.color == "RED":
            return True
        else:
            return False
```