### PR TITLE
Updated ObjectField to allow for unmapped keys

### DIFF
--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -115,6 +115,9 @@ class ObjectField(DEDField, Object):
                     obj, field_value_to_ignore
                 )
 
+        if not data and obj and isinstance(obj, dict):
+            data = obj
+
         return data
 
     def get_value_from_instance(self, instance, field_value_to_ignore=None):
@@ -125,7 +128,7 @@ class ObjectField(DEDField, Object):
         if objs is None:
             return {}
         try:
-            is_iterable = bool(iter(objs))
+            is_iterable = bool(iter(objs)) and not isinstance(objs, dict)
         except TypeError:
             is_iterable = False
         

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -131,7 +131,7 @@ class ObjectField(DEDField, Object):
             is_iterable = bool(iter(objs))
         except TypeError:
             is_iterable = False
-        
+
         if is_iterable and not isinstance(objs, dict):
             return [
                 self._get_inner_field_data(obj, field_value_to_ignore)

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -128,11 +128,11 @@ class ObjectField(DEDField, Object):
         if objs is None:
             return {}
         try:
-            is_iterable = bool(iter(objs)) and not isinstance(objs, dict)
+            is_iterable = bool(iter(objs))
         except TypeError:
             is_iterable = False
         
-        if is_iterable:
+        if is_iterable and not isinstance(objs, dict):
             return [
                 self._get_inner_field_data(obj, field_value_to_ignore)
                 for obj in objs if obj != field_value_to_ignore

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -115,6 +115,8 @@ class ObjectField(DEDField, Object):
                     obj, field_value_to_ignore
                 )
 
+        # This allows for ObjectFields to be indexed from dicts with
+        # dynamic keys (i.e. keys/fields not defined in 'properties')
         if not data and obj and isinstance(obj, dict):
             data = obj
 
@@ -132,6 +134,8 @@ class ObjectField(DEDField, Object):
         except TypeError:
             is_iterable = False
 
+        # While dicts are iterable, they need to be excluded here so
+        # their full data is indexed
         if is_iterable and not isinstance(objs, dict):
             return [
                 self._get_inner_field_data(obj, field_value_to_ignore)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -100,6 +100,36 @@ class ObjectFieldTestCase(TestCase):
             'last_name': "bar",
         })
 
+    def test_get_value_from_instance_with_partial_properties(self):
+        field = ObjectField(
+            attr='person',
+            properties={
+                'first_name': TextField(analyzer='foo')
+            }
+        )
+
+        instance = NonCallableMock(
+            person=NonCallableMock(first_name='foo', last_name='bar')
+        )
+
+        self.assertEqual(field.get_value_from_instance(instance), {
+            'first_name': "foo"
+        })
+
+    def test_get_value_from_instance_without_properties(self):
+        field = ObjectField(attr='person')
+
+        instance = NonCallableMock(
+            person={'first_name': 'foo', 'last_name': 'bar'}
+        )
+
+        self.assertEqual(field.get_value_from_instance(instance),
+            {
+                'first_name': "foo",
+                'last_name': "bar"
+            }
+        )
+
     def test_get_value_from_instance_with_inner_objectfield(self):
         field = ObjectField(attr='person', properties={
             'first_name': TextField(analyzier='foo'),
@@ -119,6 +149,30 @@ class ObjectFieldTestCase(TestCase):
             'last_name': "bar",
             'aditional': {'age': 12}
         })
+
+    def test_get_value_from_instance_with_inner_objectfield_without_properties(self):
+        field = ObjectField(
+            attr='person',
+            properties={
+                'first_name': TextField(analyzer='foo'),
+                'last_name': TextField(),
+                'additional': ObjectField()
+            }
+        )
+
+        instance = NonCallableMock(person=NonCallableMock(
+            first_name="foo",
+            last_name="bar",
+            additional={'age': 12}
+        ))
+
+        self.assertEqual(field.get_value_from_instance(instance),
+            {
+                'first_name': "foo",
+                'last_name': "bar",
+                'additional': {'age': 12}
+            }
+        )
 
     def test_get_value_from_instance_with_none_inner_objectfield(self):
         field = ObjectField(attr='person', properties={
@@ -167,6 +221,29 @@ class ObjectFieldTestCase(TestCase):
                 'last_name': "bar2",
             }
         ])
+
+    def test_get_value_from_iterable_without_properties(self):
+        field = ObjectField(attr='person')
+
+        instance = NonCallableMock(
+            person=[
+                {'first_name': "foo1", 'last_name': "bar1"},
+                {'first_name': "foo2", 'last_name': "bar2"}
+            ]
+        )
+
+        self.assertEqual(field.get_value_from_instance(instance),
+            [
+                {
+                    'first_name': "foo1",
+                    'last_name': "bar1",
+                },
+                {
+                    'first_name': "foo2",
+                    'last_name': "bar2",
+                }
+            ]
+        )
 
 
 class NestedFieldTestCase(TestCase):


### PR DESCRIPTION
I adjusted the ObjectField class to allow for data with unmapped keys. Previously, if an ObjectField (or NestedField) was created without mapping, it'd show up empty in the index.

For example:
```
# Source data
{"make": "BMW", "model": "M5"}

# documents.py
class Car(Document):
    data = fields.ObjectField()

# Index before fix
"_source" : {
    "data": [
        {}
    ]
}

# Index after fix
"_source" : {
    "data": {
        "make": "BMW",
        "model": "M5"
    }
}
```


This prevents the need for the workaround mentioned in #36, which uses a `prepare_` function such as this:
```
def prepare_data(self, instance):
    return instance.data
```

This fixes issues highlighted in #13, #36, and #235.