### PR TITLE
Fix minor documentation typos

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -8,7 +8,7 @@ Report bugs or propose enhancements through  `github bug tracker`_
 _`github bug tracker`: https://github.com/sabricot/django-elasticsearch-dsl/issues
 
 
-If you wan't to contribute, the code is on github:
+If you want to contribute, the code is on github:
 https://github.com/sabricot/django-elasticsearch-dsl
 
 Testing

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -21,7 +21,7 @@ ELASTICSEARCH_DSL_AUTO_REFRESH
 
 Default: ``True``
 
-Set to ``False`` not force an [index refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html) with every save.
+Set to ``False`` not force an `index refresh <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html>`_ with every save.
 
 ELASTICSEARCH_DSL_SIGNAL_PROCESSOR
 ==================================


### PR DESCRIPTION
- Use of Markdown link instead of reStructuredText.
- Typo: wan't instead of want