### PR TITLE
Set default_app_config only in Django 3.1 or less

### DIFF
--- a/django_elasticsearch_dsl/__init__.py
+++ b/django_elasticsearch_dsl/__init__.py
@@ -11,4 +11,5 @@ def autodiscover():
     autodiscover_modules('documents')
 
 
-default_app_config = 'django_elasticsearch_dsl.apps.DEDConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'django_elasticsearch_dsl.apps.DEDConfig'

--- a/django_elasticsearch_dsl/__init__.py
+++ b/django_elasticsearch_dsl/__init__.py
@@ -1,3 +1,5 @@
+import django
+
 from django.utils.module_loading import autodiscover_modules
 
 from .documents import Document  # noqa


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery

default_app_config is deprecated starting in 3.2, so a project in that version using this library with Deprecation Warnings enabled gets a warning about it.

This pull request sets the variable only if the django version is previous to 3.2