### PR TITLE
Allow for ObjectFields to call prepare_func included in InnerDoc.

### DIFF
--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -114,10 +114,10 @@ class ObjectField(DEDField, Object):
 
                 # This allows for retrieving data from an InnerDoc with prepare_field_name functions.
                 doc_instance = self._doc_class()
-                fn = getattr(doc_instance, 'prepare_%s' % name, None)
+                prep_func = getattr(doc_instance, 'prepare_%s' % name, None)
 
-                if fn:
-                    data[name] = fn(obj)
+                if prep_func:
+                    data[name] = prep_func(obj)
                 else:
                     data[name] = field.get_value_from_instance(
                         obj, field_value_to_ignore

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -112,9 +112,16 @@ class ObjectField(DEDField, Object):
                 if field._path == []:
                     field._path = [name]
 
-                data[name] = field.get_value_from_instance(
-                    obj, field_value_to_ignore
-                )
+                # This allows for retrieving data from an InnerDoc with prepare_field_name functions.
+                doc_instance = self._doc_class()
+                fn = getattr(doc_instance, 'prepare_%s' % name, None)
+
+                if fn:
+                    data[name] = fn(obj)
+                else:
+                    data[name] = field.get_value_from_instance(
+                        obj, field_value_to_ignore
+                    )
 
         # This allows for ObjectFields to be indexed from dicts with
         # dynamic keys (i.e. keys/fields not defined in 'properties')

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -192,11 +192,11 @@ class DocTypeTestCase(TestCase):
             class Index:
                 name = 'car_index'
 
-        self.manufacturer = Manufacturer(
+        manufacturer = Manufacturer(
             name="Bugatti",
         )
 
-        car = Car(name="Type 57", price=5400000.0, manufacturer=self.manufacturer)
+        car = Car(name="Type 57", price=5400000.0, manufacturer=manufacturer)
         doc = CarDocumentWithInnerDoc()
         prepared_data = doc.prepare(car)
         self.assertEqual(
@@ -205,7 +205,7 @@ class DocTypeTestCase(TestCase):
                 'price': car.price,
                 'manufacturer': {
                     'name': car.manufacturer.name,
-                    'location': ManufacturerInnerDoc().prepare_location(self.manufacturer)
+                    'location': ManufacturerInnerDoc().prepare_location(manufacturer)
                 }
             }
         )


### PR DESCRIPTION
These changes allow for adding prepare_functions inside subclassed `InnerDoc`. This is very useful if documents need to index some Django model which needs to include some prepare_fields.

For example, we can have a `ManufacturerInnerDoc` that’s included as a `manufacturer = fields.ObjectField(doc_class=ManufacturerInnerDoc)`, and also as class `ManufacturerDocument(Document, ManufacturerInnerDoc)`.

This allows for more reusability of fields in different indexes and on its own document. We can now only defined 1 `InnerDoc` and use on the main Document (if needed) and any other Document.