### PR TITLE
Link to Elasticsearch DSL `Search` docs on Quickstart page

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -141,6 +141,7 @@ but it is also possible to convert the elastisearch result into a real django qu
 just be aware that this costs a sql request to retrieve the model instances
 with the ids returned by the elastisearch query.
 
+.. _Search: https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#the-search-object
 .. _elasticsearch_dsl: http://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#response
 
 .. code-block:: python


### PR DESCRIPTION
The Quickstart doc page references Elasticsearch DSL `Search` docs but does not link to that page.

This PR links `Search_` to the Elasticsearch DSL `The Search object` page.

https://github.com/django-es/django-elasticsearch-dsl/blob/092f136aa21933a92652fccc63302377dc831c3b/docs/source/quickstart.rst#L124