### PR TITLE
Add option to update only specific fields while indexing documents

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -119,15 +119,20 @@ class DocType(DSLDocument):
         """
         Take a model instance, and turn it into a dict that can be serialized
         based on the fields defined on this DocType subclass
+        optionally, update_fields can be passed to index only specific fields
         """
-        data = {}
-
-        for name, field, prep_func in self._prepared_fields:
-            if isinstance(update_fields, (list, tuple, set)):
-                if name in update_fields:
-                    data.update({name: prep_func(instance)})
-            else:
-                data.update({name: prep_func(instance)})
+        if isinstance(update_fields, (list, tuple, set)):
+            # Only include `update_fields` for indexing
+            data = {
+                name: prep_func(instance)
+                for name, field, prep_func in self._prepared_fields
+                if name in update_fields
+            }
+        else:
+            data = {
+                name: prep_func(instance)
+                for name, field, prep_func in self._prepared_fields
+            }
 
         return data
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -127,7 +127,7 @@ class DocumentRegistry(object):
             if related is not None:
                 doc_instance.update(related, **kwargs)
 
-    def update(self, instance, **kwargs):
+    def update(self, instance, update_fields=None, **kwargs):
         """
         Update all the elasticsearch documents attached to this model (if their
         ignore_signals flag allows it)
@@ -138,7 +138,11 @@ class DocumentRegistry(object):
         if instance.__class__ in self._models:
             for doc in self._models[instance.__class__]:
                 if not doc.django.ignore_signals:
-                    doc().update(instance, **kwargs)
+                    doc().update(
+                        instance,
+                        update_fields=update_fields,
+                        **kwargs
+                    )
 
     def delete(self, instance, **kwargs):
         """

--- a/django_elasticsearch_dsl/signals.py
+++ b/django_elasticsearch_dsl/signals.py
@@ -48,13 +48,13 @@ class BaseSignalProcessor(object):
         elif action in ('pre_remove', 'pre_clear'):
             self.handle_pre_delete(sender, instance)
 
-    def handle_save(self, sender, instance, **kwargs):
+    def handle_save(self, sender, instance, update_fields=None, **kwargs):
         """Handle save.
 
         Given an individual model instance, update the object in the index.
         Update the related objects either.
         """
-        registry.update(instance)
+        registry.update(instance, update_fields=update_fields)
         registry.update_related(instance)
 
     def handle_pre_delete(self, sender, instance, **kwargs):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -226,9 +226,9 @@ class DocTypeTestCase(TestCase):
         doc = CarDocument()
         car = Car(
             pk=51,
-            name="Type 57",
+            name="Car 57",
             price=5400000.0,
-            not_indexed="not_indexex"
+            type="truck"
         )
 
         with patch('django_elasticsearch_dsl.documents.bulk') as mock:
@@ -242,9 +242,10 @@ class DocTypeTestCase(TestCase):
                 },
                 '_index': 'car_index'
             }]
-            self.assertEqual(1, mock.call_count)
+            self.assertEqual(mock.call_count, 1)
             self.assertEqual(
-                actions, list(mock.call_args_list[0][1]['actions'])
+                actions,
+                list(mock.call_args_list[0][1]['actions'])
             )
 
     def test_model_instance_iterable_update(self):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -228,17 +228,17 @@ class DocTypeTestCase(TestCase):
             pk=51,
             name="Car 57",
             price=5400000.0,
-            type="truck"
+            not_indexed="not_indexex"
         )
 
         with patch('django_elasticsearch_dsl.documents.bulk') as mock:
-            doc.update(car, update_fields=['name', 'price'])
+            doc.update(car, update_fields=['name', 'color'])
             actions = [{
                 '_id': car.pk,
                 '_op_type': 'index',
                 '_source': {
                     'name': car.name,
-                    'price': car.price
+                    'color': doc.prepare_color(None),
                 },
                 '_index': 'car_index'
             }]

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -75,8 +75,30 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
 
         self.assertFalse(doc_a3.update.called)
         self.assertFalse(self.doc_b1.update.called)
-        self.doc_a1.update.assert_called_once_with(instance)
-        self.doc_a2.update.assert_called_once_with(instance)
+        self.doc_a1.update.assert_called_once_with(instance, update_fields=None)
+        self.doc_a2.update.assert_called_once_with(instance, update_fields=None)
+
+    def test_partial_update_instance(self):
+        doc_a3 = self._generate_doc_mock(
+            self.ModelA, self.index_1, _ignore_signals=True
+        )
+
+        instance = self.ModelA()
+        self.registry.update(
+            instance,
+            update_fields=['test_field', 'test_field_2']
+        )
+
+        self.assertFalse(doc_a3.update.called)
+        self.assertFalse(self.doc_b1.update.called)
+        self.doc_a1.update.assert_called_once_with(
+            instance,
+            update_fields=['test_field', 'test_field_2']
+        )
+        self.doc_a2.update.assert_called_once_with(
+            instance,
+            update_fields=['test_field', 'test_field_2']
+        )
 
     def test_update_related_instances(self):
         doc_d1 = self._generate_doc_mock(
@@ -133,8 +155,16 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
 
         self.assertFalse(doc_a3.update.called)
         self.assertFalse(self.doc_b1.update.called)
-        self.doc_a1.update.assert_called_once_with(instance, action='delete')
-        self.doc_a2.update.assert_called_once_with(instance, action='delete')
+        self.doc_a1.update.assert_called_once_with(
+            instance,
+            update_fields=None,
+            action='delete'
+        )
+        self.doc_a2.update.assert_called_once_with(
+            instance,
+            update_fields=None,
+            action='delete'
+        )
 
     def test_autosync(self):
         settings.ELASTICSEARCH_DSL_AUTOSYNC = False


### PR DESCRIPTION
This PR adds an option to update only specific fields of a document in Elasticsearch. See the referenced issue for more details.

Some things to think about:

On `Model.save(update_fields=['some_field'])`, the `update_fields=['some_field']` is also passed to the signals and the signals pass that to `registry.update()` method. Though it can be a good thing but can create issues if not carefully used. such as not updating non-model fields on the document that depends on the updated fields as only `'some_field'` will be updated.

These changes also require some documentation as well, but I'm not sure where to put it. We can put the docs on the `Index` documentation page.

Closes https://github.com/django-es/django-elasticsearch-dsl/issues/277

CC: @safwanrahman 