### PR TITLE
Fix DocType._get_actions preventing delete

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -51,8 +51,10 @@ model_field_class_to_field_class = {
     models.UUIDField: KeywordField,
 }
 
+
 class DocType(DSLDocument):
     _prepared_fields = []
+
     def __init__(self, related_instance_to_ignore=None, **kwargs):
         super(DocType, self).__init__(**kwargs)
         self._related_instance_to_ignore = related_instance_to_ignore
@@ -125,8 +127,8 @@ class DocType(DSLDocument):
         """
         data = {
             name: prep_func(instance)
-                for name, field, prep_func in self._prepared_fields
-            }
+            for name, field, prep_func in self._prepared_fields
+        }
         return data
 
     @classmethod

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -188,7 +188,7 @@ class DocType(DSLDocument):
 
     def _get_actions(self, object_list, action):
         for object_instance in object_list:
-            if self.should_index_object(object_instance):
+            if action == 'delete' or self.should_index_object(object_instance):
                 yield self._prepare_action(object_instance, action)
 
     def _bulk(self, *args, **kwargs):
@@ -201,7 +201,7 @@ class DocType(DSLDocument):
 
     def should_index_object(self, obj):
         """
-        Overwriting this method and returning a boolean value 
+        Overwriting this method and returning a boolean value
         should determine whether the object should be indexed.
         """
         return True

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -1,4 +1,3 @@
-import collections
 from types import MethodType
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -108,7 +107,7 @@ class ObjectField(DEDField, Object):
                     obj, field_value_to_ignore
                 )
         else:
-            for name, field in self._doc_class._doc_type.mapping.properties._params.get('properties', {}).items(): # noqa
+            for name, field in self._doc_class._doc_type.mapping.properties._params.get('properties', {}).items():  # noqa
                 if not isinstance(field, DEDField):
                     continue
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -5,7 +5,7 @@ from itertools import chain
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ImproperlyConfigured
-from elasticsearch_dsl import Field, AttrDict
+from elasticsearch_dsl import AttrDict
 from six import itervalues, iterkeys, iteritems
 
 from django_elasticsearch_dsl.exceptions import RedeclaredFieldError

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -1,5 +1,5 @@
 from elasticsearch_dsl import analyzer
-from django_elasticsearch_dsl import Document, Index, fields
+from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
 
 from .models import Ad, Category, Car, Manufacturer, Article
@@ -159,6 +159,7 @@ class ArticleDocument(Document):
     class Index:
         name = 'test_articles'
         settings = index_settings
+
 
 @registry.register_document
 class ArticleWithSlugAsIdDocument(Document):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -3,18 +3,17 @@ from unittest import TestCase
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from elasticsearch_dsl import GeoPoint, MetaField
-from mock import patch, Mock, PropertyMock
+from elasticsearch_dsl import GeoPoint
+from mock import patch, Mock
 
 from django_elasticsearch_dsl import fields
-from django_elasticsearch_dsl.documents import DocType, Document
+from django_elasticsearch_dsl.documents import DocType
 from django_elasticsearch_dsl.exceptions import (ModelFieldNotMappedError,
                                                  RedeclaredFieldError)
 from django_elasticsearch_dsl.registries import registry
 from tests import ES_MAJOR_VERSION
 
 from .models import Article
-from .documents import ArticleDocument, ArticleWithSlugAsIdDocument
 
 
 class Car(models.Model):
@@ -72,7 +71,6 @@ class DocTypeTestCase(TestCase):
         self.assertTrue(CarDocument.django.auto_refresh)
 
     def test_ignore_signal_added(self):
-
         @registry.register_document
         class CarDocument2(DocType):
             class Django:
@@ -138,20 +136,20 @@ class DocTypeTestCase(TestCase):
 
         self.assertEqual(
             CarDocument._doc_type.mapping.to_dict(), {
-                    'properties': {
-                        'name': {
-                            'type': text_type
-                        },
-                        'color': {
-                            'type': text_type
-                        },
-                        'type': {
-                            'type': text_type
-                        },
-                        'price': {
-                            'type': 'double'
-                        }
+                'properties': {
+                    'name': {
+                        'type': text_type
+                    },
+                    'color': {
+                        'type': text_type
+                    },
+                    'type': {
+                        'type': text_type
+                    },
+                    'price': {
+                        'type': 'double'
                     }
+                }
             }
         )
 
@@ -322,7 +320,7 @@ class DocTypeTestCase(TestCase):
         bulk = "django_elasticsearch_dsl.documents.bulk"
         parallel_bulk = "django_elasticsearch_dsl.documents.parallel_bulk"
         with patch(bulk) as mock_bulk, patch(parallel_bulk) as mock_parallel_bulk:
-            doc.update([car3, car2, car3])
+            doc.update([car1, car2, car3])
             self.assertEqual(
                 3, len(list(mock_bulk.call_args_list[0][1]['actions']))
             )
@@ -353,13 +351,13 @@ class DocTypeTestCase(TestCase):
 
         expect = {
             'color': ("<class 'django_elasticsearch_dsl.fields.TextField'>",
-                    ("<class 'method'>", "<type 'instancemethod'>")), # py3, py2
+                      ("<class 'method'>", "<type 'instancemethod'>")),  # py3, py2
             'type': ("<class 'django_elasticsearch_dsl.fields.TextField'>",
-                    ("<class 'functools.partial'>","<type 'functools.partial'>")),
+                     ("<class 'functools.partial'>", "<type 'functools.partial'>")),
             'name': ("<class 'django_elasticsearch_dsl.fields.TextField'>",
-                    ("<class 'functools.partial'>","<type 'functools.partial'>")),
+                     ("<class 'functools.partial'>", "<type 'functools.partial'>")),
             'price': ("<class 'django_elasticsearch_dsl.fields.DoubleField'>",
-                    ("<class 'functools.partial'>","<type 'functools.partial'>")),
+                      ("<class 'functools.partial'>", "<type 'functools.partial'>")),
         }
 
         for name, field, prep in d._prepared_fields:
@@ -375,8 +373,8 @@ class DocTypeTestCase(TestCase):
         car = Car()
         setattr(car, 'name', "Tusla")
         setattr(car, 'price', 340123.21)
-        setattr(car, 'color', "polka-dots") # Overwritten by prepare function
-        setattr(car, 'pk', 4701) # Ignored, not in document
+        setattr(car, 'color', "polka-dots")  # Overwritten by prepare function
+        setattr(car, 'pk', 4701)  # Ignored, not in document
         setattr(car, 'type', "imaginary")
 
         self.assertEqual(d.prepare(car), {'color': 'blue', 'type': 'imaginary', 'name': 'Tusla', 'price': 340123.21})
@@ -388,8 +386,8 @@ class DocTypeTestCase(TestCase):
         with patch.object(CarDocument, '_fields', 33):
             d.prepare(m)
         self.assertEqual(sorted([tuple(x) for x in m.method_calls], key=lambda _: _[0]),
-                         [('name', (), {}),  ('price', (), {}), ('type', (), {})]
-        )
+                         [('name', (), {}), ('price', (), {}), ('type', (), {})]
+                         )
 
     # Mock the elasticsearch connection because we need to execute the bulk so that the generator
     # got iterated and generate_id called.
@@ -401,6 +399,7 @@ class DocTypeTestCase(TestCase):
             id=124594,
             slug='some-article',
         )
+
         @registry.register_document
         class ArticleDocument(DocType):
             class Django:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -124,11 +124,11 @@ class ObjectFieldTestCase(TestCase):
         )
 
         self.assertEqual(field.get_value_from_instance(instance),
-            {
-                'first_name': "foo",
-                'last_name': "bar"
-            }
-        )
+                         {
+                             'first_name': "foo",
+                             'last_name': "bar"
+                         }
+                         )
 
     def test_get_value_from_instance_with_inner_objectfield(self):
         field = ObjectField(attr='person', properties={
@@ -167,12 +167,12 @@ class ObjectFieldTestCase(TestCase):
         ))
 
         self.assertEqual(field.get_value_from_instance(instance),
-            {
-                'first_name': "foo",
-                'last_name': "bar",
-                'additional': {'age': 12}
-            }
-        )
+                         {
+                             'first_name': "foo",
+                             'last_name': "bar",
+                             'additional': {'age': 12}
+                         }
+                         )
 
     def test_get_value_from_instance_with_none_inner_objectfield(self):
         field = ObjectField(attr='person', properties={
@@ -233,17 +233,17 @@ class ObjectFieldTestCase(TestCase):
         )
 
         self.assertEqual(field.get_value_from_instance(instance),
-            [
-                {
-                    'first_name': "foo1",
-                    'last_name': "bar1",
-                },
-                {
-                    'first_name': "foo2",
-                    'last_name': "bar2",
-                }
-            ]
-        )
+                         [
+                             {
+                                 'first_name': "foo1",
+                                 'last_name': "bar1",
+                             },
+                             {
+                                 'first_name': "foo2",
+                                 'last_name': "bar2",
+                             }
+                         ]
+                         )
 
 
 class NestedFieldTestCase(TestCase):
@@ -279,17 +279,6 @@ class DateFieldTestCase(TestCase):
 
         self.assertEqual({
             'type': 'date',
-        }, field.to_dict())
-
-
-class TextFieldTestCase(TestCase):
-    def test_get_mapping(self):
-        field = TextField()
-
-        expected_type = 'string' if ES_MAJOR_VERSION == 2 else 'text'
-
-        self.assertEqual({
-            'type': expected_type,
         }, field.to_dict())
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,6 @@ from .documents import (
     car_index,
     CarDocument,
     CarWithPrepareDocument,
-    ManufacturerDocument,
     ArticleDocument,
     ArticleWithSlugAsIdDocument,
     index_settings
@@ -359,8 +358,8 @@ class IntegrationTestCase(ESTestCase, TestCase):
             slug=article_slug,
         )
 
-        # saving should create two documents (in the two indices): one with the 
-        # Django object's id as the ES doc _id, and the other with the slug 
+        # saving should create two documents (in the two indices): one with the
+        # Django object's id as the ES doc _id, and the other with the slug
         # as the ES _id
         article.save()
 
@@ -377,8 +376,8 @@ class IntegrationTestCase(ESTestCase, TestCase):
             slug=article_slug,
         )
 
-        # saving should create two documents (in the two indices): one with the 
-        # Django object's id as the ES doc _id, and the other with the slug 
+        # saving should create two documents (in the two indices): one with the
+        # Django object's id as the ES doc _id, and the other with the slug
         # as the ES _id
         article.save()
 


### PR DESCRIPTION
Hi everybody, thank you for the good work here.

There is a case when ES index is not updated on instance deletion :

If we base our should_index_object method on manytomany field, when we delete an object, the related objects are deleted before the object itself and doesnt exists anymore when should_index_object method is called.

Thus, should_index_object return is incoherent in this case and the ES index is not updated.

I think we should not call should_index on delete action, what do you think ?

I also corrected some flake8 errors.