### PR TITLE
Tested against Django 3.1 and 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       matrix:
         python-version: ["2.7", "3.6", "3.7", "3.8"]
-        django-version: ["1.11", "2.0", "2.2", "2.1", "3.0"]
+        django-version: ["1.11", "2.0", "2.2", "2.1", "3.0", "3.1","3.2"]
         es-dsl-version: ["6.4", "7.4"]
         es-version: ["7.13.4"]
 
@@ -27,6 +27,10 @@ jobs:
             django-version: "2.2"
           - python-version: "2.7"
             django-version: "3.0"
+          - python-version: "2.7"
+            django-version: "3.1"
+          - python-version: "2.7"
+            django-version: "3.2"
 
           - python-version: "3.8"
             django-version: "1.11"

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -127,3 +127,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/runtests.py
+++ b/runtests.py
@@ -30,6 +30,7 @@ try:
                                             '127.0.0.1:9200')
                 },
             },
+            DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
         )
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ setup(
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django-111-es74
-    {py36,py37,py38}-django-{111,20,21,22,30}-{es64,es74}
+    {py36,py37,py38}-django-{111,20,21,22,30,31,32}-{es64,es74}
 
 [testenv]
 setenv =
@@ -14,6 +14,8 @@ deps =
     django-21: Django>=2.1,<2.2
     django-22: Django>=2.2,<2.3
     django-30: Django>=3.0,<3.1
+    django-31: Django>=3.1,<3.2
+    django-32: Django>=3.2,<3.3
     es64: elasticsearch-dsl>=6.4.0,<7.0.0
     es74: elasticsearch-dsl>=7.4.0,<8
     -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
### Description
- Tested against Django 3.1
- Tested against Django 3.2
- Updated Classifiers
- Add `DEFAULT_AUTO_FIELD` to test settings and example project

### Related Issue
see [django/django@b5e12d4](https://github.com/django/django/commit/b5e12d490af3debca8c55ab3c1698189fdedbbdb)
