### PR TITLE
fix log message in search_index populate command

### DIFF
--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -116,7 +116,7 @@ class Command(BaseCommand):
         parallel = options['parallel']
         for doc in registry.get_documents(models):
             self.stdout.write("Indexing {} '{}' objects {}".format(
-                doc().get_queryset().count() if options['count'] else "all",
+                doc().get_indexing_queryset().count() if options['count'] else "all",
                 doc.django.model.__name__,
                 "(parallel)" if parallel else "")
             )


### PR DESCRIPTION
Hello and thanks for maintaining such an awesome library! 

I noticed while running the `search_index --rebuild` command that the number of documents being indexed is incorrect in the log message. It looks like this is because the count in the log message is filtered by `get_queryset` instead of the `get_indexing_queryset` which is used in the actual indexing process.

Thanks again!

