### PR TITLE
Misspelling geoshapefield in doc

### DIFF
--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -221,7 +221,7 @@ Available Fields
   - ``IpField(attr=None, **elasticsearch_properties)``
   - ``KeywordField(attr=None, **elasticsearch_properties)``
   - ``GeoPointField(attr=None, **elasticsearch_properties)``
-  - ``GeoShapField(attr=None, **elasticsearch_properties)``
+  - ``GeoShapeField(attr=None, **elasticsearch_properties)``
   - ``ShortField(attr=None, **elasticsearch_properties)``
   - ``TextField(attr=None, **elasticsearch_properties)``
 


### PR DESCRIPTION
The `GeoShapField(attr=None, **elasticsearch_properties)` should be `GeoShapeField(attr=None, **elasticsearch_properties)` in the documentation. It misses a `e` in the shape.  