### PR TITLE
Add output_field to preserved_order CASE

### DIFF
--- a/django_elasticsearch_dsl/search.py
+++ b/django_elasticsearch_dsl/search.py
@@ -1,4 +1,5 @@
 from django.db.models import Case, When
+from django.db.models.fields import IntegerField
 
 from elasticsearch_dsl import Search as DSLSearch
 
@@ -32,7 +33,8 @@ class Search(DSLSearch):
 
         if keep_order:
             preserved_order = Case(
-                *[When(pk=pk, then=pos) for pos, pk in enumerate(pks)]
+                *[When(pk=pk, then=pos) for pos, pk in enumerate(pks)],
+                output_field=IntegerField()
             )
             qs = qs.order_by(preserved_order)
 


### PR DESCRIPTION
Hi, this PR adds `output_field` to ensure everything's right

I'm not really sure how nobody encountered this, but without specifying `output_field` I was getting errors while annotating. Here's my code:

```python
In [3]: BookDocument.search().query("fuzzy", title='qwerty').to_queryset().annotate(a=ArrayAgg("person_relations__per
   ...: son__name"))
... ElasticsearchWarning: Elasticsearch built-in security features are not enabled. ..
Out[3]: <repr-error 'Cannot resolve expression type, unknown output_field'>

In [4]: Book.objects.filter(title='qwerty').annotate(a=ArrayAgg("person_relations__person__name"))
Out[4]: <QuerySet []>

In [5]: BookDocument.search().query("fuzzy", title='qwerty').to_queryset().annotate(a=F("person_relations__person__na
   ...: me"))
Out[5]: <QuerySet []>
```

Notice, how this only happens when using `ArrayAgg` aggregation from `django.contrib.postgres.aggregates`

Deps

- django: 3.1
- django-elasticsearch-dsl: 7.2.0
- elasticsearch: 7.15.1
- elasticsearch-dsl: 7.4.0
- (docker)postgres: 12