### PR TITLE
fields.py: force_text to force_str

### DIFF
--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -3,7 +3,7 @@ from types import MethodType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.fields.files import FieldFile
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from elasticsearch_dsl.field import (
     Boolean,
@@ -86,7 +86,7 @@ class DEDField(Field):
 
         # convert lazy object like lazy translations to string
         if isinstance(instance, Promise):
-            return force_text(instance)
+            return force_str(instance)
 
         return instance
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0

without advancing too much I believe that it is the deleted import of Django 4