### PR TITLE
Add Django 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8"]
-        django-version: ["1.11", "2.0", "2.2", "2.1", "3.0", "3.1","3.2"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        django-version: ["1.11", "2.0", "2.2", "2.1", "3.0", "3.1","3.2", "4.0"]
         es-dsl-version: ["6.4", "7.4"]
         es-version: ["7.13.4"]
 
@@ -31,6 +31,14 @@ jobs:
             django-version: "3.1"
           - python-version: "2.7"
             django-version: "3.2"
+          - python-version: "2.7"
+            django-version: "4.0"
+
+          - python-version: "3.6"
+            django-version: "4.0"
+
+          - python-version: "3.7"
+            django-version: "4.0"
 
           - python-version: "3.8"
             django-version: "1.11"
@@ -38,6 +46,26 @@ jobs:
             django-version: "2.0"
           - python-version: "3.8"
             django-version: "2.1"
+
+          - python-version: "3.9"
+            django-version: "1.11"
+          - python-version: "3.9"
+            django-version: "2.0"
+          - python-version: "3.9"
+            django-version: "2.1"
+
+          - python-version: "3.10"
+            django-version: "1.11"
+          - python-version: "3.10"
+            django-version: "2.0"
+          - python-version: "3.10"
+            django-version: "2.1"
+          - python-version: "3.10"
+            django-version: "2.2"
+          - python-version: "3.10"
+            django-version: "3.0"
+          - python-version: "3.10"
+            django-version: "3.1"
 
     steps:
       - name: Install and Run Elasticsearch

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -1,9 +1,13 @@
 from types import MethodType
 
+import django
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.fields.files import FieldFile
-from django.utils.encoding import force_text
+if django.VERSION < (4, 0):
+    from django.utils.encoding import force_text as force_str
+else:
+    from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from elasticsearch_dsl.field import (
     Boolean,
@@ -86,7 +90,7 @@ class DEDField(Field):
 
         # convert lazy object like lazy translations to string
         if isinstance(instance, Promise):
-            return force_text(instance)
+            return force_str(instance)
 
         return instance
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -68,5 +69,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+import django
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION < (4, 0):
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from six import python_2_unicode_compatible
 
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,8 +1,12 @@
 import json
 from unittest import TestCase
 
+import django
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION < (4, 0):
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from elasticsearch_dsl import GeoPoint, InnerDoc
 from mock import patch, Mock
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,11 @@
 from unittest import TestCase
 
+import django
 from django.db.models.fields.files import FieldFile
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION < (4, 0):
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from mock import Mock, NonCallableMock
 from six import string_types
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,13 @@
 from datetime import datetime
 import unittest
 
+import django
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION < (4, 0):
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from six import StringIO
 
 from elasticsearch.exceptions import NotFoundError

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django-111-es74
-    {py36,py37,py38}-django-{111,20,21,22,30,31,32}-{es64,es74}
+    {py36,py37,py38,py39,py310}-django-{111,20,21,22,30,31,32,40}-{es64,es74}
 
 [testenv]
 setenv =
@@ -16,6 +16,7 @@ deps =
     django-30: Django>=3.0,<3.1
     django-31: Django>=3.1,<3.2
     django-32: Django>=3.2,<3.3
+    django-40: Django>=4.0,<4.1
     es64: elasticsearch-dsl>=6.4.0,<7.0.0
     es74: elasticsearch-dsl>=7.4.0,<8
     -r{toxinidir}/requirements_test.txt
@@ -25,3 +26,5 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
+    py310: python3.10


### PR DESCRIPTION
* `force_text` was removed in favor of `force_str`
* `ugettext_lazy` was removed in favor of `gettext_lazy`
* added Python 3.9 and 3.10 to the test matrix, because they're supported by Django 4.0 (while excluding Django versions, which do not support 3.9 and 3.10)