### PR TITLE
Fix registries.update not deleting invalid documents

### DIFF
--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -138,7 +138,10 @@ class DocumentRegistry(object):
         if instance.__class__ in self._models:
             for doc in self._models[instance.__class__]:
                 if not doc.django.ignore_signals:
-                    doc().update(instance, **kwargs)
+                    if not doc().should_index_object(instance):
+                        doc().update(instance, action="delete")
+                    else:
+                        doc().update(instance, **kwargs)
 
     def delete(self, instance, **kwargs):
         """


### PR DESCRIPTION
Hello Everybody, thanks for all the good work here !

There is a case when ES index is not updated on instance deletion :

If we have a should_index_object method configured, we should not be permitted to index documents that do not validate should-index-object.

Lets say i have a document who firstly validate the should_index_object method, then it will be indexed.

Then i update this document, the update method should take into account if this document still validates the should_index_object, and if it does not, deleting it from the index. 

If it's still mean to stay in the index, we update him in the index.

Or maybe should we have another method named "should_delete_object" that will be called on every update ? 

What do you think ?