### PR TITLE
Add mapping for PositiveBigIntegerField type

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -42,6 +42,7 @@ model_field_class_to_field_class = {
     models.ImageField: FileField,
     models.IntegerField: IntegerField,
     models.NullBooleanField: BooleanField,
+    models.PositiveBigIntegerField: LongField,
     models.PositiveIntegerField: IntegerField,
     models.PositiveSmallIntegerField: ShortField,
     models.SlugField: KeywordField,


### PR DESCRIPTION
This change allows ES to index Django model fields that are of the PositiveBigIntegerField type.

https://docs.djangoproject.com/en/4.1/ref/models/fields/#positivebigintegerfield