### PR TITLE
feat: Queryset can now be filtered when populating index.

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -91,17 +91,24 @@ class DocType(DSLDocument):
             model=cls.django.model
         )
 
-    def get_queryset(self):
+    def get_queryset(self, filter=None, exclude=None):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        return self.django.model._default_manager.all()
+        qs = self.django.model._default_manager.all()
 
-    def get_indexing_queryset(self):
+        if filter:
+            qs = qs.filter(filter)
+        if exclude:
+            qs = qs.exclude(exclude)
+
+        return qs
+
+    def get_indexing_queryset(self, filter=None, exclude=None):
         """
         Build queryset (iterator) for use by indexing.
         """
-        qs = self.get_queryset()
+        qs = self.get_queryset(filter=filter, exclude=exclude)
         kwargs = {}
         if DJANGO_VERSION >= (2,) and self.django.queryset_pagination:
             kwargs = {'chunk_size': self.django.queryset_pagination}

--- a/django_elasticsearch_dsl/management/parsers.py
+++ b/django_elasticsearch_dsl/management/parsers.py
@@ -1,0 +1,66 @@
+import datetime
+from typing import Union, List
+
+from dateutil.parser import isoparse
+from django.conf import settings
+from django.utils.timezone import make_aware, is_aware
+
+
+def datetime_parser(value):
+    """Try to parse the given value as an ISO 8601's datetime."""
+    try:
+        date = isoparse(value)
+        if not is_aware(date):
+            date = make_aware(date)
+        return date
+    except ValueError:
+        return ...
+
+
+def int_parser(value):
+    """Try to parse the given value as an integer."""
+    try:
+        return int(value)
+    except ValueError:
+        return ...
+
+
+def float_parser(value):
+    """Try to parse the given value as a float."""
+    try:
+        return float(value)
+    except ValueError:
+        return ...
+
+
+def none_parser(value):
+    """Try to parse the given value as a float."""
+    return None if value == "" else ...
+
+
+def list_parser(value):
+    """Try to parse the given value as a comma-separated list of values."""
+    if "," in value:
+        return [parse(v.strip()) for v in value.split(",")]
+    return ...
+
+
+def parse(value):
+    """Try to coerce a string into a different type.
+
+    The order in which the parsers are called matters as some type might include
+    other, e.g. `float_parser()` would match an `int` as a `float` if called
+    before `int_parser()`.
+
+    If no parser were able to parse the value, it is returned as a string.
+    """
+    parsers = getattr(
+        settings,
+        "OPENSEARCH_DSL_VALUE_PARSERS",
+        [none_parser, int_parser, float_parser, datetime_parser, list_parser]
+    )
+    for parser in parsers:
+        v = parser(value)
+        if v != ...:  # noqa
+            return v
+    return value


### PR DESCRIPTION
The idea of this MR is to allow filtering the queryset when populating the index.

Note that this only work by filtering models (with `--models`) which have the same column.

---

`filter` and `exclude` arguments have been added to the methods `DocType.get_queryset` and `DocType.get_indexing_queryset()`. They take a Django `Q` object (both default to `None`) and are applied to the queryset.

Similarly, parameters `--filter` and `--exclude` have been added to the `search_index` command.

These parameters take a list of filter in the form `<lookup>=<value>`. Almost all django lookups are supported, including one chaining another (e.g. `date_column__year__gt`)  and lookup spanning relationship (`e.g.manufacturer__name`).

The value can either be `None` (`nullable_column=`) an `int` (`integer_column=2`), a `float` (`float_column=2.1`), a `datetime` (`datetime_column=2020-12-20T12:34+02:00`) or a list of the previous types (`integer_column=2,3,4`).
If none of the types above matched, the value will be interpreted as a string.

BREAKING CHANGE: Indices which overrode `get_indexing_queryset` or `get_queryset` need to define the `filter=None` and `exlude=None` arguments.