### PR TITLE
fix: TypeError unexpected query set model, compare correct object type, for version 7.4

### DIFF
--- a/django_elasticsearch_dsl/search.py
+++ b/django_elasticsearch_dsl/search.py
@@ -20,7 +20,7 @@ class Search(DSLSearch):
         It costs a query to the sql db.
         """
         s = self
-        if s._model is not queryset.model:
+        if s._model._wrapped is not queryset.model:
             raise TypeError(
                 'Unexpected queryset model '
                 '(should be: %s, got: %s)' % (s._model, queryset.model)


### PR DESCRIPTION

I am using django-elasticsearch-dsl version 7.4 and I want to contribute with this correction that caused the following problem:

> <h1 style="padding: 0px; margin: 0px; font-weight: normal; color: rgb(0, 0, 0); font-family: sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">TypeError at /en/search/</h1><pre class="exception_value" style="padding: 0px; margin: 10px 0px; font-size: 1.5em; white-space: pre-wrap; font-family: sans-serif; color: rgb(87, 87, 87); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Unexpected queryset model (should be: &lt;class 'myshop.models.Product'&gt;, got: &lt;class 'myshop.models.Product'&gt;)</pre>


As a consequence and cause of this implementation:


    def filter_queryset(self, queryset, keep_search_order=True):
        """
        Filter an existing django queryset using the elasticsearch result.
        It costs a query to the sql db.
        """
        s = self
        if s._model is not queryset.model:
            raise TypeError( …
                'Unexpected queryset model '
                '(should be: %s, got: %s)' % (s._model, queryset.model)
            )
        # Do not query again if the es result is already cached
        if not hasattr(self, '_response'):
        
        
        Verifying and debugging we observe that the variables are different :
        
![ArcoLinux_2023-10-10_19-31-54](https://github.com/django-es/django-elasticsearch-dsl/assets/1105101/03b80a2d-962e-466c-96b4-5d666f0f0587)


We observe that the models are not the same, it is because they are not showing the correct thing.

The solution is to add ._wrapped after ._model
        
