### PR TITLE
Prevent deprecation warning

### DIFF
--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -298,7 +298,7 @@ class Command(BaseCommand):
         # conflicts with indices, therefore this is needed regardless
         # of using the '--use-alias' arg.
         aliases = []
-        for index in self.es_conn.indices.get_alias().values():
+        for index in self.es_conn.indices.get_alias(index='*,-.*').values():
             aliases += index['aliases'].keys()
 
         if action == 'create':


### PR DESCRIPTION
Pull request to fix a Elasticsearch deprecation warning because get_alias fetches hidden indices. I think this could only cause problems when users use indices that also start with a dot, but I'm not sure if that's even allowed and it's certainly not best practice.