### PR TITLE
[docs] Sphinx v8 compatibility: configure a non-empty inventory name for Python Intersphinx mapping.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -299,7 +299,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    '': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/', None),
     'es-py': ('https://elasticsearch-py.readthedocs.io/en/master/', None) ,
     'es-dsl': ('https://elasticsearch-dsl.readthedocs.io/en/latest/', None),
 }


### PR DESCRIPTION
From [Sphinx](https://github.com/sphinx-doc/sphinx/) version 8.0 onwards, some legacy behaviours of the `intersphinx_mapping` configuration setting will be dropped, and validation of Intersphinx mapping names is being tightened to require non-empty mapping names.

Based on a [code search on GitHub](https://github.com/search?q=path%3Aconf.py+intersphinx_mapping+%2F%5E%5B+%5D*%5B%27%22%5D%5B%27%22%5D%3A+%5C%28%2F&type=code) I discovered your project as one that is recently-maintained and has an `intersphinx_mapping` configuration containing an empty-string name entry.  Because only a small number of source repositories are affected, I'm opening pull requests to offer corresponding configuration updates.

Note: I'm unfamiliar with the details of the `django-elasticsearch-dsl` documentation, so the extent of my testing has been:

  * Install a minimal set of dependencies for the project.
  * Build the project as HTML using Sphinx v7.4.7 (the latest and perhaps last pre-v8.x release).
  * Confirmed that the documentation build succeeded.

I did notice two warnings during the build:

  * A fallback default `language` value of `en` was used by the build (it may make sense to configure this statically).
  * A failure to retrieve an inventory from `https://elasticsearch-py.readthedocs.io/en/master/objects.inv` occurred - this isn't directly related to the empty-string change, but does also relate to the `intersphinx_mapping` config.  The preferred alternative path seems to be of the form: `https://elasticsearch-py.readthedocs.io/en/latest/objects.inv`