### PR TITLE
Add DenseVectorField

### DIFF
--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -15,6 +15,7 @@ from elasticsearch_dsl.field import (
     Byte,
     Completion,
     Date,
+    DenseVector,
     Double,
     Field,
     Float,
@@ -200,6 +201,8 @@ class DoubleField(DEDField, Double):
 class FloatField(DEDField, Float):
     pass
 
+class DenseVectorField(DEDField, DenseVector):
+    pass
 
 class ScaledFloatField(DEDField, ScaledFloat):
     pass

--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -217,6 +217,7 @@ Available Fields
   - ``DoubleField(attr=None, **elasticsearch_properties)``
   - ``FileField(attr=None, **elasticsearch_properties)``
   - ``FloatField(attr=None, **elasticsearch_properties)``
+  - ``DenseVectorField(attr=None, **elasticsearch_properties)``
   - ``IntegerField(attr=None, **elasticsearch_properties)``
   - ``IpField(attr=None, **elasticsearch_properties)``
   - ``KeywordField(attr=None, **elasticsearch_properties)``

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,7 +12,7 @@ from six import string_types
 from django_elasticsearch_dsl.exceptions import VariableLookupError
 from django_elasticsearch_dsl.fields import (BooleanField, ByteField, CompletionField, DEDField,
                                              DateField, DoubleField, FileField, FloatField,
-                                             GeoPointField,
+                                             DenseVectorField, GeoPointField,
                                              GeoShapeField, IntegerField, IpField, KeywordField,
                                              ListField, LongField,
                                              NestedField, ObjectField, ScaledFloatField, ShortField, TextField
@@ -343,6 +343,14 @@ class DoubleFieldTestCase(TestCase):
 class FloatFieldTestCase(TestCase):
     def test_get_mapping(self):
         field = FloatField()
+
+        self.assertEqual({
+            'type': 'float',
+        }, field.to_dict())
+
+class FloatFieldTestCase(TestCase):
+    def test_get_mapping(self):
+        field = DenseVectorField()
 
         self.assertEqual({
             'type': 'float',


### PR DESCRIPTION
Per discussion at https://github.com/django-es/django-elasticsearch-dsl/issues/356 , `django-elasticsearch-dsl` lacks a `DenseVectorField` corresponding to the `DenseVector` field defined in `elasticsearch-dsl`

https://github.com/elastic/elasticsearch-dsl-py/blob/579f57205c395e17024d9ae827cbf6fd626969c4/elasticsearch_dsl/field.py#L392-L397

This PR adds this field type.

