### PR TITLE
Restrict version of elasticsearch-dsl-py to <= 8.17.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'elasticsearch-dsl>=8.9.0,<9.0.0',
+        'elasticsearch-dsl>=8.9.0,<=8.17.1',
         'six',
     ],
     license="Apache Software License 2.0",


### PR DESCRIPTION
This commit pins the dependency of elasticsearch-dsl-py to <= 8.17.1 because after this version elasticsearch-dsl-py is deprecated and merged into elasticsearch-py

I have spent some time playing around with this package to try and understand how we can add ES9 support and I think I have a working understanding. Over the next few days I am going to work on PRs that will hopefully improve the CI setup and add ES9 support.

This will close #493 

I have seen the PRs #492  and #494 and neither of them are quite right