### PR TITLE
Switch from elasticsearch-dsl-py dependency to elasticsearch-py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["3.2", "4.1", "4.2"]
         es-dsl-version: ["6.4", "7.4"]
-        es-version: ["8.10.2"]
+        es-version: ["9.0.2"]
 
         exclude:
           - python-version: "3.11"

--- a/README.rst
+++ b/README.rst
@@ -12,17 +12,17 @@ Django Elasticsearch DSL
     :target: https://django-elasticsearch-dsl.readthedocs.io/en/latest/
 
 Django Elasticsearch DSL is a package that allows indexing of django models in elasticsearch.
-It is built as a thin wrapper around elasticsearch-dsl-py_
-so you can use all the features developed by the elasticsearch-dsl-py team.
+It is built as a thin wrapper around elasticsearch-py_
+so you can use all the features developed by the elasticsearch-py team.
 
 You can view the full documentation at https://django-elasticsearch-dsl.readthedocs.io
 
-.. _elasticsearch-dsl-py: https://github.com/elastic/elasticsearch-dsl-py
+.. _elasticsearch-py: https://github.com/elastic/elasticsearch-py
 
 Features
 --------
 
-- Based on elasticsearch-dsl-py_ so you can make queries with the Search_ class.
+- Based on elasticsearch-py_ so you can make queries with the Search_ class.
 - Django signal receivers on save and delete for keeping Elasticsearch in sync.
 - Management commands for creating, deleting, rebuilding and populating indices.
 - Elasticsearch auto mapping from django models fields.

--- a/django_elasticsearch_dsl/apps.py
+++ b/django_elasticsearch_dsl/apps.py
@@ -1,8 +1,7 @@
 from django.apps import AppConfig
 from django.conf import settings
 from django.utils.module_loading import import_string
-
-from elasticsearch_dsl.connections import connections
+from elasticsearch.dsl.connections import connections
 
 
 class DEDConfig(AppConfig):

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -6,8 +6,8 @@ from functools import partial
 
 from django import VERSION as DJANGO_VERSION
 from django.db import models
+from elasticsearch.dsl import Document as DSLDocument
 from elasticsearch.helpers import bulk, parallel_bulk
-from elasticsearch_dsl import Document as DSLDocument
 from six import iteritems
 
 from .exceptions import ModelFieldNotMappedError
@@ -21,7 +21,8 @@ from .fields import (
     KeywordField,
     LongField,
     ShortField,
-    TextField, TimeField,
+    TextField,
+    TimeField,
 )
 from .search import Search
 from .signals import post_index
@@ -219,13 +220,12 @@ class DocType(DSLDocument):
         for object_instance in object_list:
             if action == 'delete' or self.should_index_object(object_instance):
                 yield self._prepare_action(object_instance, action)
-    
+
     def get_actions(self, object_list, action):
         """
         Generate the elasticsearch payload.
         """
         return self._get_actions(object_list, action)
-
 
     def _bulk(self, *args, **kwargs):
         """Helper for switching between normal and parallel bulk operation"""

--- a/django_elasticsearch_dsl/indices.py
+++ b/django_elasticsearch_dsl/indices.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from elasticsearch_dsl import Index as DSLIndex
+from elasticsearch.dsl import Index as DSLIndex
 from six import python_2_unicode_compatible
 
 from .apps import DEDConfig

--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -1,10 +1,12 @@
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, unicode_literals
+
 from datetime import datetime
 
-from elasticsearch_dsl import connections
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from elasticsearch.dsl import connections
 from six.moves import input
+
 from ...registries import registry
 
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -1,14 +1,13 @@
 from collections import defaultdict
 from copy import deepcopy
-
 from itertools import chain
 
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.exceptions import ImproperlyConfigured
-from elasticsearch_dsl import AttrDict
-from six import itervalues, iterkeys, iteritems
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from elasticsearch.dsl import AttrDict
+from six import iteritems, iterkeys, itervalues
 
 from django_elasticsearch_dsl.exceptions import RedeclaredFieldError
+
 from .apps import DEDConfig
 
 

--- a/django_elasticsearch_dsl/search.py
+++ b/django_elasticsearch_dsl/search.py
@@ -1,7 +1,6 @@
 from django.db.models import Case, When
 from django.db.models.fields import IntegerField
-
-from elasticsearch_dsl import Search as DSLSearch
+from elasticsearch.dsl import Search as DSLSearch
 
 
 class Search(DSLSearch):

--- a/django_elasticsearch_dsl/test/testcases.py
+++ b/django_elasticsearch_dsl/test/testcases.py
@@ -1,7 +1,7 @@
 import re
 
 from django.test.utils import captured_stderr
-from elasticsearch_dsl.connections import connections
+from elasticsearch.dsl.connections import connections
 
 from ..registries import registry
 

--- a/docs/source/es_index.rst
+++ b/docs/source/es_index.rst
@@ -4,7 +4,7 @@ Index
 In typical scenario using `class Index` on a `Document` class is sufficient to perform any action.
 In a few cases though it can be useful to manipulate an Index object directly.
 
-To define an Elasticsearch index you must instantiate a ``elasticsearch_dsl.Index`` class
+To define an Elasticsearch index you must instantiate a ``elasticsearch.dsl.Index`` class
 and set the name and settings of the index.
 After you instantiate your class,
 you need to associate it with the Document you want to put in this Elasticsearch index
@@ -14,7 +14,7 @@ and also add the `registry.register_document` decorator.
 .. code-block:: python
 
     # documents.py
-    from elasticsearch_dsl import Index
+    from elasticsearch.dsl import Index
     from django_elasticsearch_dsl import Document
     from .models import Car, Manufacturer
 

--- a/example/test_app/documents.py
+++ b/example/test_app/documents.py
@@ -1,9 +1,9 @@
-from elasticsearch_dsl import analyzer
+from elasticsearch.dsl import analyzer
+
 from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl.registries import registry
 
 from .models import Ad, Car, Manufacturer
-
 
 car = Index('test_cars')
 car.settings(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=3.2
-elasticsearch-dsl>=8.0.0,<9.0.0
+elasticsearch>=8.18.0,<9.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 bumpversion==0.6.0
-wheel==0.41.2
+wheel==0.45.1
 django>=3.2
-elasticsearch-dsl>=7.0.0,<8.0.0
+elasticsearch>=8.18.0,<9.0.0
 twine
 sphinx
 -e .

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'elasticsearch-dsl>=8.9.0,<=8.17.1',
+        'elasticsearch>=8.18.0,<9.0.0',
         'six',
     ],
     license="Apache Software License 2.0",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-from elasticsearch_dsl import VERSION
+from elasticsearch import VERSION
 
 ES_MAJOR_VERSION = VERSION[0]

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -1,8 +1,9 @@
-from elasticsearch_dsl import analyzer
+from elasticsearch.dsl import analyzer
+
 from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
 
-from .models import Ad, Category, Car, Manufacturer, Article
+from .models import Ad, Article, Car, Category, Manufacturer
 
 index_settings = {
     'number_of_shards': 1,

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,7 +1,5 @@
 import json
-from unittest import TestCase
-from unittest import SkipTest
-
+from unittest import SkipTest, TestCase
 
 import django
 from django.db import models
@@ -10,13 +8,16 @@ if django.VERSION < (4, 0):
     from django.utils.translation import ugettext_lazy as _
 else:
     from django.utils.translation import gettext_lazy as _
-from elasticsearch_dsl import GeoPoint, InnerDoc
-from mock import patch, Mock
+
+from elasticsearch.dsl import GeoPoint, InnerDoc
+from mock import Mock, patch
 
 from django_elasticsearch_dsl import fields
 from django_elasticsearch_dsl.documents import DocType
-from django_elasticsearch_dsl.exceptions import (ModelFieldNotMappedError,
-                                                 RedeclaredFieldError)
+from django_elasticsearch_dsl.exceptions import (
+    ModelFieldNotMappedError,
+    RedeclaredFieldError,
+)
 from django_elasticsearch_dsl.registries import registry
 from tests import ES_MAJOR_VERSION
 
@@ -453,7 +454,7 @@ class BaseDocTypeTestCase(object):
     # got iterated and generate_id called.
     # If we mock the bulk in django_elasticsearch_dsl.document
     # the actual bulk will be never called and the test will fail
-    @patch('elasticsearch_dsl.connections.Elasticsearch.bulk')
+    @patch('elasticsearch.dsl.connections.Elasticsearch.bulk')
     def test_default_generate_id_is_called(self, _):
         article = Article(
             id=124594,
@@ -481,7 +482,7 @@ class BaseDocTypeTestCase(object):
             d.update(article)
             patched_method.assert_called()
 
-    @patch('elasticsearch_dsl.connections.Elasticsearch.bulk')
+    @patch('elasticsearch.dsl.connections.Elasticsearch.bulk')
     def test_custom_generate_id_is_called(self, mock_bulk):
         article = Article(
             id=54218,
@@ -511,7 +512,7 @@ class BaseDocTypeTestCase(object):
         data = json.loads(mock_bulk.call_args[1]['operations'][1])
         assert data['slug'] == article.slug
 
-    @patch('elasticsearch_dsl.connections.Elasticsearch.bulk')
+    @patch('elasticsearch.dsl.connections.Elasticsearch.bulk')
     def test_should_index_object_is_called(self, mock_bulk):
         doc = CarDocument()
         car1 = Car()
@@ -525,7 +526,7 @@ class BaseDocTypeTestCase(object):
             self.assertEqual(mock_should_index_object.call_count, 3,
                              "should_index_object is called")
 
-    @patch('elasticsearch_dsl.connections.Elasticsearch.bulk')
+    @patch('elasticsearch.dsl.connections.Elasticsearch.bulk')
     def test_should_index_object_working_perfectly(self, mock_bulk):
         article1 = Article(slug='article1')
         article2 = Article(slug='article2')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,31 +1,33 @@
-from datetime import datetime
 import unittest
+from datetime import datetime
 
 import django
 from django.core.management import call_command
 from django.test import TestCase, TransactionTestCase
+
 if django.VERSION < (4, 0):
     from django.utils.translation import ugettext_lazy as _
 else:
     from django.utils.translation import gettext_lazy as _
+
+from elasticsearch.dsl import Index as DSLIndex
+from elasticsearch.exceptions import NotFoundError
 from six import StringIO
 
-from elasticsearch.exceptions import NotFoundError
-from elasticsearch_dsl import Index as DSLIndex
 from django_elasticsearch_dsl.test import ESTestCase, is_es_online
 from tests import ES_MAJOR_VERSION
 
 from .documents import (
-    ad_index,
     AdDocument,
-    car_index,
-    CarDocument,
-    CarWithPrepareDocument,
     ArticleDocument,
     ArticleWithSlugAsIdDocument,
-    index_settings
+    CarDocument,
+    CarWithPrepareDocument,
+    ad_index,
+    car_index,
+    index_settings,
 )
-from .models import Car, Manufacturer, Ad, Category, Article, COUNTRIES
+from .models import COUNTRIES, Ad, Article, Car, Category, Manufacturer
 
 
 @unittest.skipUnless(is_es_online(), 'Elasticsearch is offline')


### PR DESCRIPTION
This PR switches the dependency of this library from elasticsearch-dsl-py to elasticsearch-py since the former was merged into the latter.

This closes #491 

**Before merging this in**, I would suggest we cut a 8.0.1 release first with what we have in the master branch. That way we fix the already broken 8.0.0 release that some people may have in production.

Then we can release this PR as 8.1.0 since all it does is change the underlying dependency

I will follow this up with another PR that will add support for ES 9, and drop support for older and unsupported dependencies that we can release as 9.0.0